### PR TITLE
update cultass to 3.5.0.

### DIFF
--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -55,7 +55,7 @@ namespace detail {
 enum class CopyInst {
     Ldmatrix = 0,  // ldmatrix for loading data from shared memory to register.
     Stmatrix = 1,
-    Lds32 = 2
+    LDSM32 = 2
 };
 
 // functor to copy data from shared memory to register file.

--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -68,8 +68,6 @@ struct CopyShared2Reg {
 template <typename SrcPtrs, typename DstTile>
 struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
     DEVICE void operator()(SrcPtrs& pos, DstTile& dst) {
-        // copy_2d_tile_s2r(pos, dst);
-
         static_assert(
             SrcPtrs::kSize == DstTile::kExecCount,
             "The data tile that a single thread loads from shared memory "

--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -50,47 +50,71 @@ struct R2SCopy2D {
     }
 };
 
+namespace detail {
+
+enum class CopyInst {
+    Ldmatrix = 0,  // ldmatrix for loading data from shared memory to register.
+    Stmatrix = 1,
+    Lds32 = 2
+};
+
+// functor to copy data from shared memory to register file.
+template <typename SrcPtrs, typename DstTile, CopyInst kCopyInst>
+struct CopyShared2Reg {
+    DEVICE void operator()();
+};
+
+// partial specialization for ldmatrix
+template <typename SrcPtrs, typename DstTile>
+struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
+    DEVICE void operator()(SrcPtrs& pos, DstTile& dst) {
+        // copy_2d_tile_s2r(pos, dst);
+
+        static_assert(
+            SrcPtrs::kSize == DstTile::kExecCount,
+            "The data tile that a single thread loads from shared memory "
+            "to its local register should have a equal shape.");
+
+        uint32_t smem_addr;
+        // cast to pointer pointing to 128-bit register array
+        uint32_t* reg = reinterpret_cast<uint32_t*>(dst.mutable_data());
+
+        for (int i = 0; i < SrcPtrs::kSize; ++i) {
+            smem_addr = __cvta_generic_to_shared(pos[i]);
+
+            asm volatile(
+                "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, "
+                "[%4];\n"
+                : "=r"(*(reg)), "=r"(*(reg + 1)), "=r"(*(reg + 2)),
+                  "=r"(*(reg + 3))
+                : "r"(smem_addr));
+
+#ifdef DEBUG
+            DstTile::dump_value(reg, 8);
+#endif
+            reg += DstTile::kRegCountPerAccess;  // advance pointer
+        }
+    }
+};
+
+}  // namespace detail
+
 /*
- * @brief FIXME(haruhi): a naive implementation to experiment with the
- * interface. Consider better implementations.
+ * @brief: use ldmatrix to loads 2D data tile from shared memory to thread's
+ *         local register.
+ *         FIXME(haruhi): a straightforward implementation is provided at the
+ *         moment. Consider a better one.
  *
  * @tparam pos: the shared memory positions accessed by the current thread.
- * @tparam dst: the dst data tile.
+ * @tparam dst: the destination data tile in register.
  */
 template <typename SrcPtrs, typename DstTile>
 DEVICE void copy_2d_tile_s2r(SrcPtrs& pos, DstTile& dst) {
-    static_assert(SrcPtrs::kSize == DstTile::kExecCount,
-                  "The data tile that a single thread loads from shared memory "
-                  "to its local register should have a equal shape.");
+    using Copy =
+        detail::CopyShared2Reg<SrcPtrs, DstTile, detail::CopyInst::Ldmatrix>;
 
-    uint32_t smem_addr;
-    // cast to pointer pointing to 128-bit register array
-    uint32_t* reg = reinterpret_cast<uint32_t*>(dst.mutable_data());
-
-    // issue the atomic memory access instruction
-    for (int i = 0; i < SrcPtrs::kSize; ++i) {
-        smem_addr = __cvta_generic_to_shared(pos[i]);
-
-        asm volatile(
-            "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
-            : "=r"(*(reg)), "=r"(*(reg + 1)), "=r"(*(reg + 2)), "=r"(*(reg + 3))
-            : "r"(smem_addr));
-
-#ifdef DEBUG
-        if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
-            half* r = (half*)(reg);
-            printf("[%d-%d]: %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, % .0f\n",
-                   threadIdx.x, i, __half2float(r[0]), __half2float(r[1]),
-                   __half2float(r[2]), __half2float(r[3]), __half2float(r[4]),
-                   __half2float(r[5]), __half2float(r[6]), __half2float(r[7]));
-        }
-#endif
-
-        // The magic number 4 here is computed as follows:
-        // Base::kAccessInBits / 8 / sizeof(uint32_t);
-        // each thread access 128-bit data that equals to 4 uint32_t elements.
-        reg += 4;  // advance pointer
-    }
+    Copy copy;
+    copy(pos, dst);
 }
 
 DEVICE void copy_2d_tile_r2s() {

--- a/include/cell/traits/b2b_gemm.hpp
+++ b/include/cell/traits/b2b_gemm.hpp
@@ -77,11 +77,12 @@ struct DynBack2BackGemmTraits : public Base {
     // instruction which requires the TileMMA configuration to be
     // fixed as follows. Make it able to be tuned by policy in
     // future implementation.
-
     using TiledMma =
         TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                 Layout<Shape<Int<kWarpPerRow>, Int<kWarpPerCol>, _1>>,
-                 Layout<Shape<_1, _2, _1>>>;
+                 Layout<Shape<_1, _2, _1>>,
+                 Tile<Int<16 * kWarpPerRow>, Int<32 * kWarpPerCol>, _16>>;
+
+    static constexpr int kThreads2 = size(TiledMma{});
 
     using SmemLayoutD =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTP>>{}));

--- a/include/cell/traits/b2b_gemm.hpp
+++ b/include/cell/traits/b2b_gemm.hpp
@@ -16,7 +16,7 @@ using namespace cute;
 namespace tl = tiledcuda::cell::tile_layout;
 
 template <typename Element_, typename CtaTileShape,
-          typename WarpShape = tiledcuda::cell::TileShape<2, 1>,
+          typename WarpShape = tiledcuda::cell::TileShape<1, 1>,
           typename Base = TraitsBase<Element_>>
 struct DynBack2BackGemmTraits : public Base {
     using Element = Element_;
@@ -39,8 +39,8 @@ struct DynBack2BackGemmTraits : public Base {
     // fixed as follows. Make it able to be tuned by policy in
     // future implementation.
     using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                              Layout<Shape<_1, _2, _1>>,
-                              Tile<Int<8 * kWarpPerRow>, Int<32>, _16>>;
+                              Layout<Shape<_1, _1, _1>>,
+                              Tile<Int<32 * kWarpPerRow>, _16, _32>>;
     static constexpr int kThreads = size(TiledMma{});
     static_assert(kThreads == kWarpPerRow * kWarpPerCol * 32);
 
@@ -62,8 +62,7 @@ struct DynBack2BackGemmTraits : public Base {
     using SmemLayoutB =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTN>, Int<kTK>>{}));
     // a [kTN, kTP] matrix in column major fashion,
-    // can be interpreted as a [kTP, kTN] matrix in row major
-    // fashion.
+    // can be interpreted as a [kTP, kTN] matrix in row major fashion.
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTP>, Int<kTN>>{}));
 

--- a/include/cell/traits/batched_gemm.hpp
+++ b/include/cell/traits/batched_gemm.hpp
@@ -12,9 +12,10 @@
 namespace tiledcuda::cell::traits {
 
 using namespace cute;
+namespace tl = tiledcuda::cell::tile_layout;
 
-template <typename Element_, typename InstructionShape, typename ValueMnk,
-          typename WarpArrangement, typename CtaTileShape,
+template <typename Element_, typename CtaTileShape,
+          typename WarpArrangement = tiledcuda::cell::TileShape<1, 2>,
           typename Base = TraitsBase<Element_>>
 struct DynBatchedGemmTraits : public Base {
     using Element = Element_;
@@ -23,36 +24,17 @@ struct DynBatchedGemmTraits : public Base {
     static constexpr int kTN = dim_size<1, CtaTileShape>;
     static constexpr int kTK = dim_size<2, CtaTileShape>;
 
+    static_assert(kTM % dim_size<0, WarpArrangement> == 0,
+                  "the M dimension of the CTA tile should be "
+                  "divisible by the "
+                  "number of warps along that that dimension.");
+    static_assert(kTN % dim_size<1, WarpArrangement> == 0,
+                  "the N dimension of the CTA tile should be "
+                  "divisible by the "
+                  "number of warps along that that dimension.");
+
     static constexpr int kWarpPerRow = dim_size<0, WarpArrangement>;
     static constexpr int kWarpPerCol = dim_size<1, WarpArrangement>;
-
-    static constexpr int kNumPerAccess = Base::kNumPerAccess;
-
-    static constexpr int kThreads = kWarpPerRow * kWarpPerCol * 32;
-
-    static constexpr int kThreadsPerCol = CeilDiv<kTK, Base::kNumPerAccess>;
-    static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
-
-    using SmemLayoutAtom = cute::Layout<Shape<_8, _32>, Stride<_32, _1>>;
-    using SmemLayoutA =
-        decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
-    using SmemLayoutB =
-        decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTN>, Int<kTK>>{}));
-
-    using ThreadShape = TileShape<kThreadsPerRow, kThreadsPerCol>;
-
-    using ThreadLayout = Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
-                                Stride<Int<kThreadsPerCol>, _1>>;
-
-    static const bool enable_cp_async = false;  // change this flag
-    using CopyInst = std::conditional_t<
-        enable_cp_async,
-        Copy_Atom<SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>, Element>,
-        Copy_Atom<DefaultCopy, Element>>;
-
-    using TiledCopy = decltype(make_tiled_copy(
-        CopyInst{}, ThreadLayout{},
-        Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
 
     // TODO(haruhi): The current implementation uses ldmatrix.x4
     // instruction which requires the TileMMA configuration to be
@@ -62,10 +44,32 @@ struct DynBatchedGemmTraits : public Base {
         TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
                  Layout<Shape<_1, _2, _1>>,
                  Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
+    static constexpr int kThreads = size(TiledMma{});
+    static_assert(kThreads == kWarpPerRow * kWarpPerCol * 32);
+
+    static constexpr int kNumPerAccess = Base::kNumPerAccess;
+    using SmemLayoutAtom = decltype(composition(
+        Swizzle<2, 3, 3>{}, tl::RowMajor<8, 4 * kNumPerAccess>{}));
+
+    static const bool enable_cp_async = false;  // change this flag
+    using CopyInst = std::conditional_t<
+        enable_cp_async,
+        Copy_Atom<SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>, Element>,
+        Copy_Atom<DefaultCopy, Element>>;
+
+    static constexpr int kThreadsPerCol = CeilDiv<kTK, Base::kNumPerAccess>;
+    static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
+    using TiledCopy = decltype(make_tiled_copy(
+        CopyInst{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
+
+    using SmemLayoutA =
+        decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
+    using SmemLayoutB =
+        decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTN>, Int<kTK>>{}));
 
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));
-
     using StoreC_R2S = cell::copy::R2SCopy2D<Element, TiledMma, SmemLayoutC>;
 };
 }  // namespace tiledcuda::cell::traits

--- a/include/cell/traits/batched_gemm.hpp
+++ b/include/cell/traits/batched_gemm.hpp
@@ -25,9 +25,10 @@ struct DynBatchedGemmTraits : public Base {
 
     static constexpr int kWarpPerRow = dim_size<0, WarpArrangement>;
     static constexpr int kWarpPerCol = dim_size<1, WarpArrangement>;
-    static constexpr int kThreads = kWarpPerRow * kWarpPerCol * 32;
 
     static constexpr int kNumPerAccess = Base::kNumPerAccess;
+
+    static constexpr int kThreads = kWarpPerRow * kWarpPerCol * 32;
 
     static constexpr int kThreadsPerCol = CeilDiv<kTK, Base::kNumPerAccess>;
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
@@ -57,11 +58,10 @@ struct DynBatchedGemmTraits : public Base {
     // instruction which requires the TileMMA configuration to be
     // fixed as follows. Make it able to be tuned by policy in
     // future implementation.
-
     using TiledMma =
         TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                 Layout<Shape<Int<kWarpPerRow>, Int<kWarpPerCol>, _1>>,
-                 Layout<Shape<_1, _2, _1>>>;
+                 Layout<Shape<_1, _2, _1>>,
+                 Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
 
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));

--- a/include/cell/traits/gemm.hpp
+++ b/include/cell/traits/gemm.hpp
@@ -32,7 +32,9 @@ struct DynGemmTraits : public Base {
     static constexpr int kThreadsPerCol = CeilDiv<kTK, Base::kNumPerAccess>;
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
 
-    using SmemLayoutAtom = cute::Layout<Shape<_8, _32>, Stride<_32, _1>>;
+    using SmemLayoutAtom = decltype(composition(
+        Swizzle<2, 3, 3>{}, cute::Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
+
     using SmemLayoutA =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
     using SmemLayoutB =
@@ -57,11 +59,10 @@ struct DynGemmTraits : public Base {
     // instruction which requires the TileMMA configuration to be
     // fixed as follows. Make it able to be tuned by policy in
     // future implementation.
-
     using TiledMma =
         TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                 Layout<Shape<Int<kWarpPerRow>, Int<kWarpPerCol>, _1>>,
-                 Layout<Shape<_1, _2, _1>>>;
+                 Layout<Shape<_1, _2, _1>>,
+                 Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
 
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));

--- a/include/cell/traits/gemm.hpp
+++ b/include/cell/traits/gemm.hpp
@@ -2,7 +2,6 @@
 
 #include "cell/copy/static_copy.hpp"
 #include "cell/traits/base.hpp"
-#include "types/tile_shape.hpp"
 
 #include <cute/arch/copy.hpp>
 #include <cute/tensor.hpp>
@@ -12,9 +11,10 @@
 namespace tiledcuda::cell::traits {
 
 using namespace cute;
+namespace tl = tiledcuda::cell::tile_layout;
 
-template <typename Element_, typename InstructionShape, typename ValueMnk,
-          typename WarpArrangement, typename CtaTileShape,
+template <typename Element_, typename CtaTileShape,
+          typename WarpArrangement = tiledcuda::cell::TileShape<1, 2>,
           typename Base = TraitsBase<Element_>>
 struct DynGemmTraits : public Base {
     using Element = Element_;
@@ -23,9 +23,27 @@ struct DynGemmTraits : public Base {
     static constexpr int kTN = dim_size<1, CtaTileShape>;
     static constexpr int kTK = dim_size<2, CtaTileShape>;
 
+    static_assert(kTM % dim_size<0, WarpArrangement> == 0,
+                  "the M dimension of the CTA tile should be "
+                  "divisible by the "
+                  "number of warps along that that dimension.");
+    static_assert(kTN % dim_size<1, WarpArrangement> == 0,
+                  "the N dimension of the CTA tile should be "
+                  "divisible by the "
+                  "number of warps along that that dimension.");
+
     static constexpr int kWarpPerRow = dim_size<0, WarpArrangement>;
     static constexpr int kWarpPerCol = dim_size<1, WarpArrangement>;
-    static constexpr int kThreads = kWarpPerRow * kWarpPerCol * 32;
+    // TODO(haruhi): The current implementation uses ldmatrix.x4
+    // instruction which requires the TileMMA configuration to be
+    // fixed as follows. Make it able to be tuned by policy in
+    // future implementation.
+    using TiledMma =
+        TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,  // for ampere
+                 Layout<Shape<_1, _2, _1>>,
+                 Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
+    static constexpr int kThreads = size(TiledMma{});
+    static_assert(kThreads == kWarpPerRow * kWarpPerCol * 32);
 
     static constexpr int kNumPerAccess = Base::kNumPerAccess;
 
@@ -33,40 +51,23 @@ struct DynGemmTraits : public Base {
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
 
     using SmemLayoutAtom = decltype(composition(
-        Swizzle<2, 3, 3>{}, cute::Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
-
+        Swizzle<2, 3, 3>{}, tl::RowMajor<8, 4 * kNumPerAccess>{}));
     using SmemLayoutA =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
     using SmemLayoutB =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTN>, Int<kTK>>{}));
-
-    using ThreadShape = TileShape<kThreadsPerRow, kThreadsPerCol>;
-
-    using ThreadLayout = Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
-                                Stride<Int<kThreadsPerCol>, _1>>;
 
     static const bool enable_cp_async = false;  // change this flag
     using CopyInst = std::conditional_t<
         enable_cp_async,
         Copy_Atom<SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>, Element>,
         Copy_Atom<DefaultCopy, Element>>;
-
     using TiledCopy = decltype(make_tiled_copy(
-        CopyInst{}, ThreadLayout{},
+        CopyInst{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
-
-    // TODO(haruhi): The current implementation uses ldmatrix.x4
-    // instruction which requires the TileMMA configuration to be
-    // fixed as follows. Make it able to be tuned by policy in
-    // future implementation.
-    using TiledMma =
-        TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                 Layout<Shape<_1, _2, _1>>,
-                 Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
 
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));
-
     using StoreC_R2S = cell::copy::R2SCopy2D<Element, TiledMma, SmemLayoutC>;
 };
 }  // namespace tiledcuda::cell::traits

--- a/include/cell/traits/lstm.hpp
+++ b/include/cell/traits/lstm.hpp
@@ -64,10 +64,10 @@ struct DynLstmGateTraits : public Base {
     // future implementation.
     using TiledMma =
         TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                 Layout<Shape<Int<kWarpPerRow>, Int<kWarpPerCol>, _1>>,
-                 Layout<Shape<_1, _2, _1>>>;
-    using SmemLoadAtom = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+                 Layout<Shape<_1, _2, _1>>,
+                 Tile<Int<16 * kWarpPerRow>, Int<16 * kWarpPerCol>, _16>>;
 
+    using SmemLoadAtom = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
     using SmemLayoutE =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));
 

--- a/include/types/register.hpp
+++ b/include/types/register.hpp
@@ -5,6 +5,35 @@
 
 namespace tiledcuda::cell {
 
+namespace detail {
+
+// for debugging purpose
+template <typename Element>
+DEVICE void dump_value(const Element* data, int numel);
+
+template <>
+DEVICE void dump_value<uint32_t>(const uint32_t* data, int numel) {
+    if (threadIdx.x || blockIdx.x || blockIdx.y) return;
+
+    const half* reg = reinterpret_cast<const half*>(data);
+
+    for (int i = 0; i < numel / 8; i += 8) {
+        printf("[tid = %d]: %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f, %.0f\n",
+               threadIdx.x, __half2float(reg[0]), __half2float(reg[1]),
+               __half2float(reg[2]), __half2float(reg[3]), __half2float(reg[4]),
+               __half2float(reg[5]), __half2float(reg[6]),
+               __half2float(reg[7]));
+    }
+
+    if (numel % 8) {
+        printf("[tid = %d]: ", threadIdx.x);
+        for (int i = numel / 8 * 8; i < numel - 1; ++i)
+            printf("%.0f, ", __half2float(reg[i]));
+        printf("%.0f\n\n", __half2float(reg[numel - 1]));
+    }
+}
+}  // namespace detail
+
 /*
  * @brief The register tile is comprised of a 2-dimensional array of data
  *        elements.
@@ -24,6 +53,10 @@ class RegTile : public Base {
     using DType = Element;
     using TemporalExec = TemporalExec_;
     using ElemTileLayout = ElemTileLayout_;
+
+    // how many 128-bit are used per access
+    constexpr static int kRegCountPerAccess =
+        Base::kAccessInBits / 8 / sizeof(uint32_t);
 
     constexpr static int kRows =
         dim_size<0, ElemTileLayout> * dim_size<0, TemporalExec>;
@@ -47,6 +80,11 @@ class RegTile : public Base {
     DEVICE DType* mutable_data() { return (DType*)data_; }
 
     DEVICE const DType* data() const { return (DType*)data_; }
+
+    template <typename T>
+    DEVICE static void dump_value(const T* data, int numel) {
+        detail::dump_value<T>(data, numel);
+    };
 
   private:
     // register tile data is implemented as an 2D array of size kRows x kCols

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -135,7 +135,7 @@ class SharedTile : public Base {
         // in a warp cooperative instruction, the threads are
         // laid out in a [2, 2] tile, and each tile has a shape of [8, 1].
         int n = lane_id / 8;
-        int lane_row = int(n / 2) * 8 + lane_id - n * 8;
+        int lane_row = n / 2 * 8 + lane_id - n * 8;
         int lane_col = n % 2;
         col_stride = Base::kNumPerAccess / 8 / sizeof(DType);
         offset = lane_row * kCols + lane_col * col_stride;

--- a/include/types/tile_shape.hpp
+++ b/include/types/tile_shape.hpp
@@ -5,13 +5,23 @@
 
 namespace tiledcuda::cell {
 
-template <size_t... T>
-using TileShape = cute::tuple<std::integral_constant<size_t, T>...>;
+template <size_t... Ns>
+struct TileShape {
+    static constexpr cute::array<size_t, sizeof...(Ns)> shape = {Ns...};
 
-template <const size_t I, typename TileShape>
-inline static constexpr size_t dim_size = cute::get<I>(TileShape{});
+    static constexpr size_t get_numel() {
+        size_t product = 1;
+        for (size_t n : shape) product *= n;
+        return product;
+    }
+
+    static constexpr size_t kNumel = get_numel();
+};
 
 template <typename TileShape>
-inline static constexpr int64_t get_numel = cute::size(TileShape{});
+inline static constexpr int64_t get_numel = TileShape::kNumel;
+
+template <const size_t I, typename TileShape>
+inline static constexpr size_t dim_size = cute::get<I>(TileShape::shape);
 
 }  // namespace tiledcuda::cell

--- a/src/kernels/b2b_gemm.cu
+++ b/src/kernels/b2b_gemm.cu
@@ -65,12 +65,10 @@ __global__ void dyn_back2back_gemm(const Element* d_a, const Element* d_b,
         gA_ptr = A;                      // A tile is repeated loaded
         gB_ptr = B + n * kK;
         for (int k = 0; k < kK; k += kTK) {  // iterate over K
-
             copy_2d_tile_g2s(gA_ptr, sA_ptr, load_a_g2s_layout,
                              typename KeTraits::SmemLayoutA{}, tiled_copy, tid);
             copy_2d_tile_g2s(gB_ptr, sB_ptr, load_b_g2s_layout,
                              typename KeTraits::SmemLayoutB{}, tiled_copy, tid);
-
             __copy_async();
             __syncthreads();
 
@@ -86,8 +84,8 @@ __global__ void dyn_back2back_gemm(const Element* d_a, const Element* d_b,
             gB_ptr += kTK;
         }
         // The output type of the first tensor core matrix multiplication is
-        // float32. However, before the second GEMM operation, the output needs
-        // to be converted to half precision.
+        // float32. However, before the second GEMM operation, the output
+        // needs to be converted to half precision.
         auto acc_half = convert_type<Element>(acc1);
         auto rA2 = convert_layout<KeTraits::TiledMma>(acc_half);
 
@@ -126,8 +124,6 @@ void cute_back2back_gemm(const Element* d_a, const Element* d_b,
 
     using KeTraits =
         cell::traits::DynBack2BackGemmTraits<Element, CtaTileShape>;
-
-    std::cout << "kThreads = " << KeTraits::kThreads << std::endl;
 
     int shm_input = (kTM * kTK + kTK * kTN + kTN * kTP);
     int shm_output = kTM * kTP;

--- a/src/kernels/b2b_gemm.cu
+++ b/src/kernels/b2b_gemm.cu
@@ -127,6 +127,9 @@ void cute_back2back_gemm(const Element* d_a, const Element* d_b,
     using KeTraits =
         cell::traits::DynBack2BackGemmTraits<Element, CtaTileShape, WarpShape>;
 
+    std::cout << "kThreads = " << KeTraits::kThreads
+              << ", kThreads2 = " << KeTraits::kThreads2 << std::endl;
+
     int shm_input = (kTM * kTK + kTK * kTN + kTN * kTP);
     int shm_output = kTM * kTP;
     int shm_size = shm_input < shm_output ? shm_output * sizeof(Element)

--- a/src/kernels/bmm.cu
+++ b/src/kernels/bmm.cu
@@ -142,8 +142,8 @@ void custom_batched_gemm_op(const torch::Tensor& a, const torch::Tensor& b,
                             int64_t batch_count) {
     using InstructionShape = cell::TileShape<16, 8, 16>;
     using ValueMnk = cell::TileShape<1, 2, 1>;
-    using WarpArrangement = cell::TileShape<1, 1, 1>;
-    using CtaTileShape = cell::TileShape<16, 32, 32>;
+    using WarpArrangement = cell::TileShape<2, 2, 1>;
+    using CtaTileShape = cell::TileShape<32, 32, 32>;
 
     auto dtype = a.dtype();
 

--- a/src/kernels/bmm.cu
+++ b/src/kernels/bmm.cu
@@ -85,13 +85,12 @@ __global__ void dyn_cute_batched_gemm_kernel(const Element* dA,
     sC.copy(acc, shm, tid);  // store register tile to shared memory
     __syncthreads();
 
+    // store shared memory tile to global memory
     copy_2d_tile_s2g(sC_ptr, gC_ptr, typename KeTraits::SmemLayoutC{},
-                     store_c_s2g_layout, tiled_copy,
-                     tid);  // store shared memory tile to global memory
+                     store_c_s2g_layout, tiled_copy, tid);
 }
 
-template <typename Element, typename InstructionShape, typename ValueMnk,
-          typename WarpArrangement, typename CtaTileShape>
+template <typename Element, typename CtaTileShape>
 void cute_batched_gemm(const Element* a, const Element* b, Element* c, int m,
                        int n, int k, int batch_count) {
     // CTA GEMM shape
@@ -99,18 +98,7 @@ void cute_batched_gemm(const Element* a, const Element* b, Element* c, int m,
     static const int kTN = dim_size<1, CtaTileShape>;
     static const int kTK = dim_size<2, CtaTileShape>;
 
-    static_assert(kTM % dim_size<0, WarpArrangement> == 0,
-                  "the M dimension of the CTA tile should be "
-                  "divisible by the "
-                  "number of warps along that that dimension.");
-    static_assert(kTN % dim_size<1, WarpArrangement> == 0,
-                  "the N dimension of the CTA tile should be "
-                  "divisible by the "
-                  "number of warps along that that dimension.");
-
-    using GemmTraits =
-        traits::DynBatchedGemmTraits<Element, InstructionShape, ValueMnk,
-                                     WarpArrangement, CtaTileShape>;
+    using GemmTraits = traits::DynBatchedGemmTraits<Element, CtaTileShape>;
 
     static constexpr int smem_size =
         std::max(kTK * (kTN + kTM), kTM * kTN) * sizeof(Element);
@@ -140,16 +128,12 @@ void cute_batched_gemm(const Element* a, const Element* b, Element* c, int m,
 void custom_batched_gemm_op(const torch::Tensor& a, const torch::Tensor& b,
                             torch::Tensor& c, int64_t m, int64_t n, int64_t k,
                             int64_t batch_count) {
-    using InstructionShape = cell::TileShape<16, 8, 16>;
-    using ValueMnk = cell::TileShape<1, 2, 1>;
-    using WarpArrangement = cell::TileShape<2, 2, 1>;
     using CtaTileShape = cell::TileShape<32, 32, 32>;
 
     auto dtype = a.dtype();
 
     if (dtype == torch::kHalf) {
-        cute_batched_gemm<cutlass::half_t, InstructionShape, ValueMnk,
-                          WarpArrangement, CtaTileShape>(
+        cute_batched_gemm<cutlass::half_t, CtaTileShape>(
             reinterpret_cast<const cutlass::half_t*>(a.const_data_ptr()),
             reinterpret_cast<const cutlass::half_t*>(b.const_data_ptr()),
             reinterpret_cast<cutlass::half_t*>(c.mutable_data_ptr()), m, n, k,

--- a/src/kernels/gemm.cu
+++ b/src/kernels/gemm.cu
@@ -78,9 +78,9 @@ __global__ void dyn_cute_gemm_kernel(const Element* dA, const Element* dB,
     sC.copy(acc, shm, tid);  // store register tile to shared memory
     __syncthreads();
 
+    // store shared memory tile to global memory
     copy_2d_tile_s2g(sC_ptr, gC_ptr, typename KeTraits::SmemLayoutC{},
-                     store_c_s2g_layout, tiled_copy,
-                     tid);  // store shared memory tile to global memory
+                     store_c_s2g_layout, tiled_copy, tid);
 }
 
 template <typename Element, typename CtaTileShape>
@@ -92,8 +92,6 @@ void cute_gemm(const Element* a, const Element* b, Element* c, int m, int n,
     static const int kTK = dim_size<2, CtaTileShape>;
 
     using GemmTraits = traits::DynGemmTraits<Element, CtaTileShape>;
-
-    std::cout << "kThreads = " << GemmTraits::kThreads << std::endl;
 
     static constexpr int smem_size =
         std::max(kTK * (kTN + kTM), kTM * kTN) * sizeof(Element);

--- a/src/kernels/gemm.cu
+++ b/src/kernels/gemm.cu
@@ -133,7 +133,7 @@ void custom_gemm_op(const torch::Tensor& a, const torch::Tensor& b,
                     torch::Tensor& c, int64_t m, int64_t n, int64_t k) {
     using InstructionShape = cell::TileShape<16, 8, 16>;
     using ValueMnk = cell::TileShape<1, 2, 1>;
-    using WarpArrangement = cell::TileShape<1, 1, 1>;
+    using WarpArrangement = cell::TileShape<1, 2, 1>;
     using CtaTileShape = cell::TileShape<16, 32, 32>;
 
     auto dtype = a.dtype();

--- a/src/kernels/lstm_cell.cu
+++ b/src/kernels/lstm_cell.cu
@@ -260,7 +260,7 @@ void custom_lstm_cell_op(const torch::Tensor& w, const torch::Tensor& x,
                          int64_t hidden_size) {
     using InstructionShape = cell::TileShape<16, 8, 16>;
     using ValueMnk = cell::TileShape<1, 2, 1>;
-    using WarpArrangement = cell::TileShape<1, 1, 1>;
+    using WarpArrangement = cell::TileShape<1, 2, 1>;
     using CtaTileShape = cell::TileShape<16, 32, 32>;
 
     auto dtype = w.dtype();

--- a/src/kernels/lstm_cell.cu
+++ b/src/kernels/lstm_cell.cu
@@ -150,8 +150,7 @@ __global__ void lstm_element_wise(const Element* i, const Element* f,
     }
 }
 
-template <typename Element, typename InstructionShape, typename ValueMnk,
-          typename WarpArrangement, typename CtaTileShape>
+template <typename Element, typename CtaTileShape>
 void lstm_gate(const Element* w, const Element* x, const Element* u,
                const Element* h, Element* t, const int m, const int n,
                const int k) {
@@ -164,18 +163,7 @@ void lstm_gate(const Element* w, const Element* x, const Element* u,
     static const int kTN = dim_size<1, CtaTileShape>;
     static const int kTK = dim_size<2, CtaTileShape>;
 
-    static_assert(kTM % dim_size<0, WarpArrangement> == 0,
-                  "the M dimension of the CTA tile should be "
-                  "divisible by the "
-                  "number of warps along that that dimension.");
-    static_assert(kTN % dim_size<1, WarpArrangement> == 0,
-                  "the N dimension of the CTA tile should be "
-                  "divisible by the "
-                  "number of warps along that that dimension.");
-
-    using KeTraits =
-        traits::DynLstmGateTraits<Element, InstructionShape, ValueMnk,
-                                  WarpArrangement, CtaTileShape>;
+    using KeTraits = traits::DynLstmGateTraits<Element, CtaTileShape>;
 
     static constexpr int smem_size =
         std::max(kTK * (kTN + kTM) * 2, kTM * kTN) * sizeof(Element);
@@ -205,8 +193,7 @@ void lstm_gate(const Element* w, const Element* x, const Element* u,
     lstm_gate<<<gridDim, blockDim, smem_size>>>(w, u, x, h, t, m, n, k);
 }
 
-template <typename Element, typename InstructionShape, typename ValueMnk,
-          typename WarpArrangement, typename CtaTileShape>
+template <typename Element, typename CtaTileShape>
 void lstm_cell(const Element* w, const Element* x, const Element* u,
                const Element* c, const Element* h, Element* c_out,
                Element* h_out, int m, int n, int k) {
@@ -220,8 +207,7 @@ void lstm_cell(const Element* w, const Element* x, const Element* u,
     Element* t;
     CudaCheck(cudaMalloc(&t, m * n * sizeof(Element)));
 
-    lstm_gate<Element, InstructionShape, ValueMnk, WarpArrangement,
-              CtaTileShape>(w, x, u, h, t, m, n, k);
+    lstm_gate<Element, CtaTileShape>(w, x, u, h, t, m, n, k);
 
     const Element* i = t;
     const Element* f = t + M * N;
@@ -258,9 +244,6 @@ void custom_lstm_cell_op(const torch::Tensor& w, const torch::Tensor& x,
                          const torch::Tensor& h0, torch::Tensor& c1,
                          torch::Tensor& h1, int64_t batch_size,
                          int64_t hidden_size) {
-    using InstructionShape = cell::TileShape<16, 8, 16>;
-    using ValueMnk = cell::TileShape<1, 2, 1>;
-    using WarpArrangement = cell::TileShape<1, 2, 1>;
     using CtaTileShape = cell::TileShape<16, 32, 32>;
 
     auto dtype = w.dtype();
@@ -270,8 +253,7 @@ void custom_lstm_cell_op(const torch::Tensor& w, const torch::Tensor& x,
     int k = hidden_size;
 
     if (dtype == torch::kHalf) {
-        lstm_cell<cutlass::half_t, InstructionShape, ValueMnk, WarpArrangement,
-                  CtaTileShape>(
+        lstm_cell<cutlass::half_t, CtaTileShape>(
             reinterpret_cast<const cutlass::half_t*>(w.const_data_ptr()),
             reinterpret_cast<const cutlass::half_t*>(x.const_data_ptr()),
             reinterpret_cast<const cutlass::half_t*>(u.const_data_ptr()),

--- a/tests/cpp/cell/test_s2f_copy.cu
+++ b/tests/cpp/cell/test_s2f_copy.cu
@@ -36,8 +36,7 @@ __device__ void print_tile(const Element* data) {
     printf("\n");
 }
 
-#define DEBUG_
-/// unittest for copy_s2r
+// unittest for copy_s2r
 template <typename Element, typename Shared, typename Reg>
 __global__ void copy_s2r() {
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
@@ -56,7 +55,6 @@ __global__ void copy_s2r() {
         }
     }
 }
-
 }  // namespace
 
 TEST(TestShm2Rf, copy_2d_tile_s2r) {

--- a/tests/cpp/kernels/test_gemm.cu
+++ b/tests/cpp/kernels/test_gemm.cu
@@ -1,9 +1,0 @@
-#include "common/test_utils.hpp"
-
-namespace tiledcuda {
-namespace testing {
-
-TEST(TestGEMM, test) {}
-
-}  // namespace testing
-}  // namespace tiledcuda

--- a/tests/python/test_gemm.py
+++ b/tests/python/test_gemm.py
@@ -11,7 +11,7 @@ class TestGemm(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(1234)
 
-    def test_gemm1(self):
+    def test_gemm(self):
 
         a = torch.randn(256, 256, device='cuda')
         b = torch.randn(256, 256, device='cuda')

--- a/tests/python/test_gemm.py
+++ b/tests/python/test_gemm.py
@@ -11,7 +11,7 @@ class TestGemm(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(1234)
 
-    def test_gemm(self):
+    def test_gemm1(self):
 
         a = torch.randn(256, 256, device='cuda')
         b = torch.randn(256, 256, device='cuda')


### PR DESCRIPTION
resolve https://github.com/TiledTensor/TiledCUDA/issues/36 resolve https://github.com/TiledTensor/TiledCUDA/issues/37

1. A simple refinement for the `copy_2d_tile_s2r` macro kernel:moving the implementation into a Functor rather than a function. This would allow for partial specialization based on the memory access instruction used.
1. Update cutlass to v3.5.0. However, after updating to Cutlass 3.5.0, the template parameter for TiledMMA has changed. While all the kernels pass the correctness check, one side effect is that I am no longer able to fully understand the register usage.