### PR TITLE
Bug fix and add unittest for load data using ldmatrix.

### DIFF
--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -69,7 +69,7 @@ struct CopyShared2Reg {
 // partial specialization for ldmatrix
 template <typename SrcPtrs, typename DstTile>
 struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
-    __device__ void operator()(SrcPtrs& pos, DstTile& dst) {
+    DEVICE void operator()(SrcPtrs& pos, DstTile& dst) {
         static_assert(
             SrcPtrs::kSize == DstTile::kExecCount,
             "The data tile that a single thread loads from shared memory "
@@ -94,8 +94,6 @@ struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
 #endif
             reg += DstTile::kRegCountPerAccess;  // advance pointer
         }
-
-        __syncwarp();
     }
 };
 

--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -69,7 +69,7 @@ struct CopyShared2Reg {
 // partial specialization for ldmatrix
 template <typename SrcPtrs, typename DstTile>
 struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
-    DEVICE void operator()(SrcPtrs& pos, DstTile& dst) {
+    __device__ void operator()(SrcPtrs& pos, DstTile& dst) {
         static_assert(
             SrcPtrs::kSize == DstTile::kExecCount,
             "The data tile that a single thread loads from shared memory "
@@ -94,6 +94,8 @@ struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
 #endif
             reg += DstTile::kRegCountPerAccess;  // advance pointer
         }
+
+        __syncwarp();
     }
 };
 

--- a/include/cell/copy/static_copy.hpp
+++ b/include/cell/copy/static_copy.hpp
@@ -85,7 +85,7 @@ struct CopyShared2Reg<SrcPtrs, DstTile, CopyInst::Ldmatrix> {
             asm volatile(
                 "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, "
                 "[%4];\n"
-                : "=r"(*(reg)), "=r"(*(reg + 1)), "=r"(*(reg + 2)),
+                : "=r"(*(reg)), "=r"(*(reg + 2)), "=r"(*(reg + 1)),
                   "=r"(*(reg + 3))
                 : "r"(smem_addr));
 

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -137,7 +137,7 @@ class SharedTile : public Base {
         int n = lane_id / 8;
         int lane_row = n / 2 * 8 + lane_id - n * 8;
         int lane_col = n % 2;
-        col_stride = Base::kNumPerAccess / 8 / sizeof(DType);
+        col_stride = Base::kAccessInBits / 8 / sizeof(DType);
         offset = lane_row * kCols + lane_col * col_stride;
         data += offset;  // advance pointer
 

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -126,13 +126,6 @@ class SharedTile : public Base {
         offset = warp_row * row_stride + warp_col * col_stride;
         data += offset;  // advance pointer
 
-        if (threadIdx.x == 32) {
-            printf("\n\nkCols = %d, kRowsPerExec = %d\n", kCols, kRowsPerExec);
-            printf("warp_row = %d, warp_col = %d\n", warp_row, warp_col);
-            printf("offset = %d, row_stride = %d, col_stride = %d\n", offset,
-                   row_stride, col_stride);
-        }
-
         // step 3. advance the pointer to shared memory position the current
         // thread inside a warp cooperative instruction (indexed by [lane_row,
         // lane_col]) access.
@@ -155,9 +148,8 @@ class SharedTile : public Base {
         int sc1 = dim_size<1, ElemTileLayout> / Base::kNumPerAccess;
 
         for (int i = 0; i < sc0; ++i) {
-            for (int j = 0; j < sc1; ++j) {
+            for (int j = 0; j < sc1; ++j)
                 shm_pos_[i * sc1 + j] = data + j * col_stride;
-            }
             data += row_stride;
         }
         return shm_pos_;

--- a/tests/cpp/cell/test_s2f_copy.cu
+++ b/tests/cpp/cell/test_s2f_copy.cu
@@ -4,8 +4,6 @@
 
 #include <glog/logging.h>
 
-// #define __CUDA_ARCH__ 800
-
 namespace tiledcuda {
 
 using namespace cell;
@@ -14,6 +12,8 @@ namespace tl = tile_layout;
 
 namespace testing {
 
+#define EPS 1e-4
+
 namespace {
 
 /// utility function
@@ -21,7 +21,17 @@ template <typename Element, const int kNumel>
 __device__ void init(Element* data) {
     if (threadIdx.x || blockIdx.x || blockIdx.y) return;
 
-    for (int i = 0; i < kNumel; ++i) data[i] = static_cast<Element>(i % 2048);
+    for (int i = 0; i < kNumel; ++i) {
+        int v = i % 2048;
+        if (v == 0) {
+            // avoid zero. the unittest checks whether the data is
+            // copied by checking whether the value loaded into the register
+            // file greater than zero.
+            data[i] = static_cast<Element>(0.1);
+        } else {
+            data[i] = static_cast<Element>(v);
+        }
+    }
 }
 
 /// utility function
@@ -36,27 +46,9 @@ __device__ void print_tile(const Element* data, int delimeter = kCols) {
     printf("\n");
 }
 
-// unittest for transferring data from shared memory to thread's local register
-// file using `ldmatrix`
-template <typename Element, typename Shared, typename Reg>
-__global__ void test_ldmatrix1() {
-    const int kRows = Shared::kRows;
-    const int kCols = Shared::kCols;
-
-    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
-    auto* buf = reinterpret_cast<Element*>(buf_);
-
-    init<Element, kRows * kCols>(buf);
-
-#ifdef DEBUG
-    print_tile<Element, kRows, kCols>(buf);
-#endif
-
-    Shared s_tiles(buf);
-    Reg r_tile;
-    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
-
-    // CuTe's configuration for issue a single ldmatrix
+/// @brief 1 warp executes 1 `ldmatrix`
+template <typename Element, typename Reg, const int kRows, const int kCols>
+__device__ const Element* cute_ldmatrix1(const Element* buf) {
     // this setting increases how many threads are used in a CTA
     using WarpLayout = Layout<Shape<_1, _1, _1>>;
     // this setting increases how many registers are used in a CTA
@@ -65,9 +57,9 @@ __global__ void test_ldmatrix1() {
     using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
                               WarpLayout, ValueLayout>;
     using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+    __syncthreads();
 
     TiledMma tiled_mma;
-
     int tid = threadIdx.x;
 
     auto row_major = tl::RowMajor<kRows, kCols>{};
@@ -80,9 +72,9 @@ __global__ void test_ldmatrix1() {
     auto thr_mma = tiled_mma.get_thread_slice(tid);
     // partitioned data tile that is loaded into the current thread's local
     // register file
-    auto reg_tile = thr_mma.partition_fragment_A(tensor);
+    auto dst = thr_mma.partition_fragment_A(tensor);
     // make the layout compatible for `tiled_copy`
-    auto dst_view = thrd_copy.retile_D(reg_tile);
+    auto dst_view = thrd_copy.retile_D(dst);
 
     for (int i = 0; i < int(size<1>(dst_view)); ++i) {
         for (int j = 0; j < int(size<2>(dst_view)); ++j)
@@ -92,239 +84,232 @@ __global__ void test_ldmatrix1() {
     int reg_tile_size = int(size(dst_view));
     assert(reg_tile_size == Reg::kNumel);
 
-    const half* data1 = reinterpret_cast<const half*>(reg_tile.data());
+    return dst.data();
+}
+
+/// @brief test 2 warps arranged in 2 x 1 row-major tile executes 4 `ldmatrix`
+///        per warp
+template <typename Element, typename Reg, const int kRows, const int kCols>
+__device__ const Element* cute_ldmatrix2(const Element* buf) {
+    // 2 warps along the m dimension.
+    // When the stride is not specified for CuTe's layout, the default layout is
+    // column-major. For our current macro kernel implementation, we treat warps
+    // as being laid out in a row-major fashion. In order to make CuTe's layout
+    // for warps also row-major, the stride must be specified.
+    using WarpLayout = Layout<Shape<_2, _1, _1>, Stride<_1, _1, _1>>;
+
+    // execute 4 `ldmatrix` along the m and n dimensions
+    using ValueLayout = Tile<_32, _16, _32>;
+    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                              WarpLayout, ValueLayout>;  // wmma 16.8.16
+    __syncthreads();
+
+    TiledMma tiled_mma;
+    int tid = threadIdx.x;
+
+    auto row_major = tl::RowMajor<kRows, kCols>{};
+    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
+
+    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
+    auto thrd_copy = tiled_copy.get_thread_slice(tid);
+    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
+
+    auto thr_mma = tiled_mma.get_thread_slice(tid);
+    // partitioned data tile loaded into the current thread's local register
+    auto dst = thr_mma.partition_fragment_A(tensor);
+    // make the layout compatible for `tiled_copy`
+    auto dst_view = thrd_copy.retile_D(dst);
+
+    // how many 128-bit registers are used per thread.
+    int reg_tile_size = int(size(dst_view));
+    assert(reg_tile_size == Reg::kNumel);
+
+    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
+        for (int j = 0; j < int(size<2>(dst_view)); ++j)
+            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
+    }
+    return dst.data();
+}
+
+template <typename Element, typename Reg, const int kRows, const int kCols,
+          const int kExec>
+__device__ const Element* cute_ldmatrix3(const Element* buf) {
+    // 2 warps along the m dimension
+    // When the stride is not specified for CuTe's layout, the default layout is
+    // column-major. For our current macro kernel implementation, we treat warps
+    // as being laid out in a row-major fashion. In order to make CuTe's layout
+    // for warps also row-major, the stride must be specified.
+    using WarpLayout_ = Layout<Shape<_2, _1, _2>, Stride<_2, _1, _1>>;
+    // execute 4 `ldmatrix` along the m and n dimensions
+    using ValueLayout = Tile<_32, _16, _32>;
+    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                              WarpLayout_, ValueLayout>;  // wmma 16.8.16
+    __syncthreads();
+
+    TiledMma tiled_mma;
+    int tid = threadIdx.x;
+
+    auto row_major = tl::RowMajor<kRows, kCols>{};
+    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
+
+    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
+    auto thrd_copy = tiled_copy.get_thread_slice(tid);
+    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
+
+    auto thr_mma = tiled_mma.get_thread_slice(tid);
+    // partitioned data tile loaded into the current thread's local register
+    auto dst = thr_mma.partition_fragment_A(tensor);
+    // make the layout compatible for `tiled_copy`
+    auto dst_view = thrd_copy.retile_D(dst);
+
+    // how many 128-bit registers are used per thread.
+    int reg_tile_size = int(size(dst_view));
+    assert(reg_tile_size == Reg::kNumel * kExec);
+
+    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
+        for (int j = 0; j < int(size<2>(dst_view)); ++j)
+            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
+    }
+    return dst.data();
+}
+
+// unittest for transferring data from shared memory to thread's local register
+// file using `ldmatrix`
+template <typename Element, typename Shared, typename Reg>
+__global__ void test_ldmatrix1() {
+    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
+    auto* buf = reinterpret_cast<Element*>(buf_);
+    init<Element, Shared::kRows * Shared::kCols>(buf);
+#ifdef DEBUG
+    print_tile<Element, Shared::kRows, Shared::kCols>(buf);
+#endif
+
+    auto data = cute_ldmatrix1<Element, Reg, Shared::kRows, Shared::kCols>(buf);
+
+    Shared s_tiles(buf);
+    Reg r_tile;
+    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
+
+    const half* data1 = reinterpret_cast<const half*>(data);
     const half* data2 = reinterpret_cast<const half*>(r_tile.data());
 
-    const float epsilon = 1e-3;
-    for (int i = 0; i < reg_tile_size; ++i) {
-        assert(__half2float(data1[i]) - __half2float(data2[i]) < epsilon);
+    for (int i = 0; i < Reg::kNumel; ++i) {
+        float v1 = __half2float(data1[i]);
+        float v2 = __half2float(data2[i]);
+
+        assert(v1);
+        assert(v2);
+        assert(abs(v1 - v2) < EPS);
     }
 }
 
 template <typename Element, typename Shared, typename Reg>
 __global__ void test_ldmatrix2() {
-    const int kRows = Shared::kRows;
-    const int kCols = Shared::kCols;
-
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
     auto* buf = reinterpret_cast<Element*>(buf_);
-    init<Element, kRows * kCols>(buf);
+    init<Element, Shared::kRows * Shared::kCols>(buf);
 
 #ifdef DEBUG
-    print_tile<Element, kRows, kCols>(buf);
+    print_tile<Element, Shared::kRows, Shared::kCols>(buf);
 #endif
+
+    auto data = cute_ldmatrix2<Element, Reg, Shared::kRows, Shared::kCols>(buf);
 
     Shared s_tiles(buf);
     Reg r_tile;
     copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
-
-    // ground-truth, CuTe's ldmatrix
-    // this setting increases how many threads are used in a CTA
-    using WarpLayout = Layout<Shape<_1, _1, _1>>;
-    // this setting increases how many registers are used in a CTA
-    using ValueLayout = Tile<_32, _16, _32>;
-    // `ldmatrix` loads four 8 x 8 tiles
-    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                              WarpLayout, ValueLayout>;
-    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
-
-    TiledMma tiled_mma;
-
-    int tid = threadIdx.x;
-
-    auto row_major = tl::RowMajor<kRows, kCols>{};
-    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
-
-    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
-    auto thrd_copy = tiled_copy.get_thread_slice(tid);
-    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
-
-    auto thr_mma = tiled_mma.get_thread_slice(tid);
-    // partitioned data tile that is loaded into the current thread's local
-    // register file
-    auto dst = thr_mma.partition_fragment_A(tensor);
-    // make the layout compatible for `tiled_copy`
-    auto dst_view = thrd_copy.retile_D(dst);
-
-    // how many 128-bit registers are used per thread.
-    int reg_tile_size = int(size(dst_view));
-    assert(reg_tile_size == Reg::kNumel);
-
-    const float epsilon = 1e-3;
-    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
-        for (int j = 0; j < int(size<2>(dst_view)); ++j)
-            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
-    }
-
-    const half* data1 = reinterpret_cast<const half*>(dst_view.data());
     const half* data2 = reinterpret_cast<const half*>(r_tile.data());
 
-    for (int i = 0; i < reg_tile_size; ++i) {
-        assert(__half2float(data1[i]) - __half2float(data2[i]) < epsilon);
+    const half* data1 = reinterpret_cast<const half*>(data);
+    for (int i = 0; i < Reg::kNumel; ++i) {
+        float v1 = __half2float(data1[i]);
+        float v2 = __half2float(data2[i]);
+
+        assert(v1);
+        assert(v2);
+        assert(abs(v1 - v2) < EPS);
     }
 }
 
-#define DEBUG_
 template <typename Element, typename Shared, typename Reg>
 __global__ void test_ldmatrix3() {
-    const int kRows = Shared::kRows;
-    const int kCols = Shared::kCols;
-
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
     auto* buf = reinterpret_cast<Element*>(buf_);
-    init<Element, kRows * kCols>(buf);
+    init<Element, Shared::kRows * Shared::kCols>(buf);
 
 #ifdef DEBUG
-    print_tile<Element, kRows, kCols>(buf);
+    print_tile<Element, Shared::kRows, Shared::kCols>(buf);
 #endif
+
+    auto data = cute_ldmatrix3<Element, Reg, Shared::kRows, Shared::kCols,
+                               Shared::sc0 * Shared::sc1>(buf);
+    const half* data1 = reinterpret_cast<const half*>(data);
 
     Shared s_tiles(buf);
     Reg r_tile;
-    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
-
-    // ground-truth, CuTe's ldmatrix
-    // this setting increases how many threads are used in a CTA
-    using WarpLayout = Layout<Shape<_2, _1, _1>>;
-    // this setting increases how many registers are used in a CTA
-    using ValueLayout = Tile<_32, _16, _32>;
-    // `ldmatrix` loads four 8 x 8 tiles
-    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
-                              WarpLayout, ValueLayout>;
-
-    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
-
-    TiledMma tiled_mma;
-
-    int tid = threadIdx.x;
-
-    auto row_major = tl::RowMajor<kRows, kCols>{};
-    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
-
-    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
-    auto thrd_copy = tiled_copy.get_thread_slice(tid);
-    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
-
-    auto thr_mma = tiled_mma.get_thread_slice(tid);
-    // partitioned data tile that is loaded into the current thread's local
-    // register file
-    auto dst = thr_mma.partition_fragment_A(tensor);
-    // make the layout compatible for `tiled_copy`
-    auto dst_view = thrd_copy.retile_D(dst);
-
-    // how many 128-bit registers are used per thread.
-    int reg_tile_size = int(size(dst_view));
-    // assert(reg_tile_size == Reg::kNumel);
-
-    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
-        for (int j = 0; j < int(size<2>(dst_view)); ++j)
-            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
-    }
-
-    const half* data1 = reinterpret_cast<const half*>(dst_view.data());
     const half* data2 = reinterpret_cast<const half*>(r_tile.data());
 
-    if (threadIdx.x == 32) {
-        printf("\ntiled mma threads = %d\n", int(size(TiledMma{})));
+    for (int i = 0; i < Shared::sc0; ++i) {
+        for (int j = 0; j < Shared::sc1; ++j) {
+            copy::copy_2d_tile_s2r(s_tiles[make_int2(i, j)], r_tile);
 
-        printf("reg_tile_size: %d\n", reg_tile_size);
-        printf("Reg::kNumel: %d\n", Reg::kNumel);
+            for (int k = 0; k < Reg::kNumel; ++k) {
+                int idx = (i * Shared::sc1 + j) * Reg::kNumel + k;
+                float v1 = __half2float(data1[idx]);
+                float v2 = __half2float(data2[k]);
 
-        printf("\nsrc layout");
-        print(layout(src));
-        printf("\ndst layout");
-        print(layout(dst));
-        printf("\ndst_view layout\n");
-        print(layout(dst_view));
-        printf("\n\n");
-
-        // const float epsilon = 1e-3;
-        for (int i = 0; i < reg_tile_size; ++i) {
-            // printf("[%d]: %.0f\n", i, __half2float(data1[i]));
-
-            printf("[%d]: %.0f, %0.f\n", i, __half2float(data1[i]),
-                   __half2float(data2[i]));
-
-            // assert(__half2float(data1[i]) - __half2float(data2[i]) <
-            // epsilon);
+                assert(v1);
+                assert(v2);
+                assert(abs(v1 - v2) < EPS);
+            }
         }
-        printf("\n");
     }
 }
 
 }  // namespace
 
-// TEST(TestShared2Reg, shape1) {
-//     // this test case represents the minimum shape that a single warp is used
-//     to
-//     // execute 1 `ldmatrix`.
-//     using Element = cutlass::half_t;
+TEST(TestShared2Reg, shape1) {
+    // the minimum shape that a single warp is used to execute 1 `ldmatrix`.
+    using Element = cutlass::half_t;
 
-//     // configuration for shared memory tile
-//     using TemporalExecShared = TileShape<1, 1>;
-//     using WarpLayout = TileShape<1, 1>;
-//     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
-//     using ElemDataTileShared = TileShape<1, 8>;
-//     // the final copy plan for accessing shared memory
-//     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
-//                               ThreadLayout, ElemDataTileShared>;
+    // configuration for shared memory tile
+    using TemporalExecShared = TileShape<1, 1>;
+    using WarpLayout = TileShape<1, 1>;
+    using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
+    using ElemDataTileShared = TileShape<1, 8>;
+    // the final copy plan for accessing shared memory
+    using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
+                              ThreadLayout, ElemDataTileShared>;
 
-//     static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
+    static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
 
-//     // configuration for register tile
-//     using TemporalExecReg = TileShape<1, 1>;
-//     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
-//     // the final copy plan for accessing local register file
-//     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
+    // configuration for register tile
+    using TemporalExecReg = TileShape<1, 1>;
+    using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
+    // the final copy plan for accessing local register file
+    using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
 
-//     const int kThreads = Shared::kThreads;
-//     // LOG(INFO) << "kThreads: " << kThreads << std::endl
-//     //           << "Shared memory tile shape: [" << Shared::kRows << ", "
-//     //           << Shared::kCols << "];" << std::endl
-//     //           << "Spatial tile shape: [" << Shared::kRowsPerExec << ", "
-//     //           << Shared::kColsPerExec << "]; " << std::endl;
+    const int kThreads = Shared::kThreads;
+    LOG(INFO) << std::endl
+              << "kThreads: " << kThreads << std::endl
+              << "Shared memory tile shape: [" << Shared::kRows << ", "
+              << Shared::kCols << "];" << std::endl
+              << "Spatial tile shape: [" << Shared::kRowsPerExec << ", "
+              << Shared::kColsPerExec << "]; " << std::endl;
 
-//     dim3 dim_grid(1, 1, 1);
-//     dim3 dim_block(kThreads, 1, 1);
+    dim3 dim_grid(1, 1, 1);
+    dim3 dim_block(kThreads, 1, 1);
 
-//     int shm_size = Shared::kNumel * sizeof(Element);
-//     test_ldmatrix1<Element, Shared, Reg><<<dim_grid, dim_block,
-//     shm_size>>>(); cudaDeviceSynchronize();
-// }
+    int shm_size = Shared::kNumel * sizeof(Element);
+    test_ldmatrix1<Element, Shared, Reg><<<dim_grid, dim_block, shm_size>>>();
+    cudaDeviceSynchronize();
+}
 
-// TEST(TestShared2Reg, shape2) {
-//     // this test case represents using a single warp is used to execute 4
-//     // `ldmatrix` along 2 dimensions.
-//     using Element = cutlass::half_t;
-
-//     // configuration for shared memory tile
-//     using TemporalExecShared = TileShape<1, 1>;
-//     using WarpLayout = TileShape<1, 1>;
-//     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
-//     using ElemDataTileShared = TileShape<2, 16>;
-//     // the final copy plan for accessing shared memory
-//     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
-//                               ThreadLayout, ElemDataTileShared>;
-
-//     static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
-
-//     // configuration for register tile
-//     using TemporalExecReg = TileShape<2, 2>;
-//     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
-//     // the final copy plan for accessing local register file
-//     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
-
-//     const int kThreads = Shared::kThreads;
-//     dim3 dim_grid(1, 1, 1);
-//     dim3 dim_block(kThreads, 1, 1);
-
-//     int shm_size = Shared::kNumel * sizeof(Element);
-//     test_ldmatrix2<Element, Shared, Reg><<<dim_grid, dim_block,
-//     shm_size>>>(); cudaDeviceSynchronize();
-// }
-
-TEST(TestShared2Reg, shape3) {
-    // this test case represents using a single warp is used to execute 4
-    // `ldmatrix` along 2 dimensions.
+TEST(TestShared2Reg, shape2) {
+    // this test case represents using 2 warps arranged as 1 x 2 and each
+    // thread executes 4 `ldmatrix` along 2 dimensions.
     using Element = cutlass::half_t;
 
     // configuration for shared memory tile
@@ -336,7 +321,41 @@ TEST(TestShared2Reg, shape3) {
     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
                               ThreadLayout, ElemDataTileShared>;
 
-    static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
+    // configuration for register tile
+    using TemporalExecReg = TileShape<2, 2>;
+    using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
+    // the final copy plan for accessing local register file
+    using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
+
+    const int kThreads = Shared::kThreads;
+    LOG(INFO) << std::endl
+              << "kThreads: " << kThreads << std::endl
+              << "Shared memory tile shape: [" << Shared::kRows << ", "
+              << Shared::kCols << "];" << std::endl
+              << "Spatial tile shape: [" << Shared::kRowsPerExec << ", "
+              << Shared::kColsPerExec << "]; " << std::endl;
+
+    dim3 dim_grid(1, 1, 1);
+    dim3 dim_block(kThreads, 1, 1);
+    int shm_size = Shared::kNumel * sizeof(Element);
+    test_ldmatrix2<Element, Shared, Reg><<<dim_grid, dim_block, shm_size>>>();
+    cudaDeviceSynchronize();
+}
+
+TEST(TestShared2Reg, shape3) {
+    // this test case represents using a single warp is used to execute 4
+    // `ldmatrix` along 2 dimensions.
+    using Element = cutlass::half_t;
+
+    // configuration for shared memory tile
+    using TemporalExecShared = TileShape<2, 1>;
+    using WarpLayout = TileShape<2, 2>;
+    using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
+    using ElemDataTileShared = TileShape<2, 16>;
+    // the final copy plan for accessing shared memory
+    using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
+                              ThreadLayout, ElemDataTileShared>;
+    static_assert(Shared::sc0 == 2 && Shared::sc1 == 1);
 
     // configuration for register tile
     using TemporalExecReg = TileShape<2, 2>;

--- a/tests/cpp/cell/test_s2f_copy.cu
+++ b/tests/cpp/cell/test_s2f_copy.cu
@@ -4,6 +4,8 @@
 
 #include <glog/logging.h>
 
+// #define __CUDA_ARCH__ 800
+
 namespace tiledcuda {
 
 using namespace cell;
@@ -34,10 +36,27 @@ __device__ void print_tile(const Element* data, int delimeter = kCols) {
     printf("\n");
 }
 
-template <typename Element, int kRows, int kCols>
-__device__ auto cute_ldmatrix(const Element* buf) {
-    // CuTe's configuration for issue a single ldmatrix
+// unittest for transferring data from shared memory to thread's local register
+// file using `ldmatrix`
+template <typename Element, typename Shared, typename Reg>
+__global__ void test_ldmatrix1() {
+    const int kRows = Shared::kRows;
+    const int kCols = Shared::kCols;
 
+    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
+    auto* buf = reinterpret_cast<Element*>(buf_);
+
+    init<Element, kRows * kCols>(buf);
+
+#ifdef DEBUG
+    print_tile<Element, kRows, kCols>(buf);
+#endif
+
+    Shared s_tiles(buf);
+    Reg r_tile;
+    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
+
+    // CuTe's configuration for issue a single ldmatrix
     // this setting increases how many threads are used in a CTA
     using WarpLayout = Layout<Shape<_1, _1, _1>>;
     // this setting increases how many registers are used in a CTA
@@ -61,40 +80,83 @@ __device__ auto cute_ldmatrix(const Element* buf) {
     auto thr_mma = tiled_mma.get_thread_slice(tid);
     // partitioned data tile that is loaded into the current thread's local
     // register file
-    auto dst = thr_mma.partition_fragment_A(tensor);
+    auto reg_tile = thr_mma.partition_fragment_A(tensor);
     // make the layout compatible for `tiled_copy`
-    auto dst_view = thrd_copy.retile_D(dst);
+    auto dst_view = thrd_copy.retile_D(reg_tile);
 
-    cute::copy(tiled_copy, src(_, _, 0), dst_view(_, _, 0));
+    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
+        for (int j = 0; j < int(size<2>(dst_view)); ++j)
+            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
+    }
 
-    return dst;
-}
+    int reg_tile_size = int(size(dst_view));
+    assert(reg_tile_size == Reg::kNumel);
 
-// unittest for transferring data from shared memory to thread's local register
-// file using `ldmatrix`
-template <typename Element, typename Shared, typename Reg>
-__global__ void test_ldmatrix_s2r() {
-    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
-    auto* buf = reinterpret_cast<Element*>(buf_);
-    init<Element, Shared::kRows * Shared::kCols>(buf);
-
-#ifdef DEBUG
-    print_tile<Element, Shared::kRows, Shared::kCols>(buf);
-#endif
+    const half* data1 = reinterpret_cast<const half*>(reg_tile.data());
+    const half* data2 = reinterpret_cast<const half*>(r_tile.data());
 
     const float epsilon = 1e-3;
+    for (int i = 0; i < reg_tile_size; ++i) {
+        assert(__half2float(data1[i]) - __half2float(data2[i]) < epsilon);
+    }
+}
+
+template <typename Element, typename Shared, typename Reg>
+__global__ void test_ldmatrix2() {
+    const int kRows = Shared::kRows;
+    const int kCols = Shared::kCols;
+
+    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
+    auto* buf = reinterpret_cast<Element*>(buf_);
+    init<Element, kRows * kCols>(buf);
+
+#ifdef DEBUG
+    print_tile<Element, kRows, kCols>(buf);
+#endif
 
     Shared s_tiles(buf);
     Reg r_tile;
     copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
 
-    // ground-truth
-    auto reg_tile = cute_ldmatrix<Element, Shared::kRows, Shared::kCols>(buf);
-    int reg_tile_size = int(size(reg_tile));
+    // ground-truth, CuTe's ldmatrix
+    // this setting increases how many threads are used in a CTA
+    using WarpLayout = Layout<Shape<_1, _1, _1>>;
+    // this setting increases how many registers are used in a CTA
+    using ValueLayout = Tile<_32, _16, _32>;
+    // `ldmatrix` loads four 8 x 8 tiles
+    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                              WarpLayout, ValueLayout>;
+    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
 
+    TiledMma tiled_mma;
+
+    int tid = threadIdx.x;
+
+    auto row_major = tl::RowMajor<kRows, kCols>{};
+    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
+
+    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
+    auto thrd_copy = tiled_copy.get_thread_slice(tid);
+    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
+
+    auto thr_mma = tiled_mma.get_thread_slice(tid);
+    // partitioned data tile that is loaded into the current thread's local
+    // register file
+    auto dst = thr_mma.partition_fragment_A(tensor);
+    // make the layout compatible for `tiled_copy`
+    auto dst_view = thrd_copy.retile_D(dst);
+
+    // how many 128-bit registers are used per thread.
+    int reg_tile_size = int(size(dst_view));
     assert(reg_tile_size == Reg::kNumel);
 
-    const half* data1 = reinterpret_cast<const half*>(reg_tile.data());
+    const float epsilon = 1e-3;
+    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
+        for (int j = 0; j < int(size<2>(dst_view)); ++j)
+            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
+    }
+
+    const half* data1 = reinterpret_cast<const half*>(dst_view.data());
     const half* data2 = reinterpret_cast<const half*>(r_tile.data());
 
     for (int i = 0; i < reg_tile_size; ++i) {
@@ -102,18 +164,174 @@ __global__ void test_ldmatrix_s2r() {
     }
 }
 
+#define DEBUG_
+template <typename Element, typename Shared, typename Reg>
+__global__ void test_ldmatrix3() {
+    const int kRows = Shared::kRows;
+    const int kCols = Shared::kCols;
+
+    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
+    auto* buf = reinterpret_cast<Element*>(buf_);
+    init<Element, kRows * kCols>(buf);
+
+#ifdef DEBUG
+    print_tile<Element, kRows, kCols>(buf);
+#endif
+
+    Shared s_tiles(buf);
+    Reg r_tile;
+    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
+
+    // ground-truth, CuTe's ldmatrix
+    // this setting increases how many threads are used in a CTA
+    using WarpLayout = Layout<Shape<_2, _1, _1>>;
+    // this setting increases how many registers are used in a CTA
+    using ValueLayout = Tile<_32, _16, _32>;
+    // `ldmatrix` loads four 8 x 8 tiles
+    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                              WarpLayout, ValueLayout>;
+
+    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+
+    TiledMma tiled_mma;
+
+    int tid = threadIdx.x;
+
+    auto row_major = tl::RowMajor<kRows, kCols>{};
+    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
+
+    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
+    auto thrd_copy = tiled_copy.get_thread_slice(tid);
+    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
+
+    auto thr_mma = tiled_mma.get_thread_slice(tid);
+    // partitioned data tile that is loaded into the current thread's local
+    // register file
+    auto dst = thr_mma.partition_fragment_A(tensor);
+    // make the layout compatible for `tiled_copy`
+    auto dst_view = thrd_copy.retile_D(dst);
+
+    // how many 128-bit registers are used per thread.
+    int reg_tile_size = int(size(dst_view));
+    // assert(reg_tile_size == Reg::kNumel);
+
+    for (int i = 0; i < int(size<1>(dst_view)); ++i) {
+        for (int j = 0; j < int(size<2>(dst_view)); ++j)
+            cute::copy(tiled_copy, src(_, i, j), dst_view(_, i, j));
+    }
+
+    const half* data1 = reinterpret_cast<const half*>(dst_view.data());
+    const half* data2 = reinterpret_cast<const half*>(r_tile.data());
+
+    if (threadIdx.x == 32) {
+        printf("\ntiled mma threads = %d\n", int(size(TiledMma{})));
+
+        printf("reg_tile_size: %d\n", reg_tile_size);
+        printf("Reg::kNumel: %d\n", Reg::kNumel);
+
+        printf("\nsrc layout");
+        print(layout(src));
+        printf("\ndst layout");
+        print(layout(dst));
+        printf("\ndst_view layout\n");
+        print(layout(dst_view));
+        printf("\n\n");
+
+        // const float epsilon = 1e-3;
+        for (int i = 0; i < reg_tile_size; ++i) {
+            // printf("[%d]: %.0f\n", i, __half2float(data1[i]));
+
+            printf("[%d]: %.0f, %0.f\n", i, __half2float(data1[i]),
+                   __half2float(data2[i]));
+
+            // assert(__half2float(data1[i]) - __half2float(data2[i]) <
+            // epsilon);
+        }
+        printf("\n");
+    }
+}
+
 }  // namespace
 
-TEST(TestShared2Reg, minimal_shape) {
-    // this test case represents the minimum shape that a single warp is used to
-    // execute 1 `ldmatrix`.
+// TEST(TestShared2Reg, shape1) {
+//     // this test case represents the minimum shape that a single warp is used
+//     to
+//     // execute 1 `ldmatrix`.
+//     using Element = cutlass::half_t;
+
+//     // configuration for shared memory tile
+//     using TemporalExecShared = TileShape<1, 1>;
+//     using WarpLayout = TileShape<1, 1>;
+//     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
+//     using ElemDataTileShared = TileShape<1, 8>;
+//     // the final copy plan for accessing shared memory
+//     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
+//                               ThreadLayout, ElemDataTileShared>;
+
+//     static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
+
+//     // configuration for register tile
+//     using TemporalExecReg = TileShape<1, 1>;
+//     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
+//     // the final copy plan for accessing local register file
+//     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
+
+//     const int kThreads = Shared::kThreads;
+//     // LOG(INFO) << "kThreads: " << kThreads << std::endl
+//     //           << "Shared memory tile shape: [" << Shared::kRows << ", "
+//     //           << Shared::kCols << "];" << std::endl
+//     //           << "Spatial tile shape: [" << Shared::kRowsPerExec << ", "
+//     //           << Shared::kColsPerExec << "]; " << std::endl;
+
+//     dim3 dim_grid(1, 1, 1);
+//     dim3 dim_block(kThreads, 1, 1);
+
+//     int shm_size = Shared::kNumel * sizeof(Element);
+//     test_ldmatrix1<Element, Shared, Reg><<<dim_grid, dim_block,
+//     shm_size>>>(); cudaDeviceSynchronize();
+// }
+
+// TEST(TestShared2Reg, shape2) {
+//     // this test case represents using a single warp is used to execute 4
+//     // `ldmatrix` along 2 dimensions.
+//     using Element = cutlass::half_t;
+
+//     // configuration for shared memory tile
+//     using TemporalExecShared = TileShape<1, 1>;
+//     using WarpLayout = TileShape<1, 1>;
+//     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
+//     using ElemDataTileShared = TileShape<2, 16>;
+//     // the final copy plan for accessing shared memory
+//     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
+//                               ThreadLayout, ElemDataTileShared>;
+
+//     static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
+
+//     // configuration for register tile
+//     using TemporalExecReg = TileShape<2, 2>;
+//     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
+//     // the final copy plan for accessing local register file
+//     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
+
+//     const int kThreads = Shared::kThreads;
+//     dim3 dim_grid(1, 1, 1);
+//     dim3 dim_block(kThreads, 1, 1);
+
+//     int shm_size = Shared::kNumel * sizeof(Element);
+//     test_ldmatrix2<Element, Shared, Reg><<<dim_grid, dim_block,
+//     shm_size>>>(); cudaDeviceSynchronize();
+// }
+
+TEST(TestShared2Reg, shape3) {
+    // this test case represents using a single warp is used to execute 4
+    // `ldmatrix` along 2 dimensions.
     using Element = cutlass::half_t;
 
     // configuration for shared memory tile
     using TemporalExecShared = TileShape<1, 1>;
-    using WarpLayout = TileShape<1, 1>;
+    using WarpLayout = TileShape<2, 1>;
     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
-    using ElemDataTileShared = TileShape<1, 8>;
+    using ElemDataTileShared = TileShape<2, 16>;
     // the final copy plan for accessing shared memory
     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
                               ThreadLayout, ElemDataTileShared>;
@@ -121,13 +339,14 @@ TEST(TestShared2Reg, minimal_shape) {
     static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
 
     // configuration for register tile
-    using TemporalExecReg = TileShape<1, 1>;
+    using TemporalExecReg = TileShape<2, 2>;
     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
     // the final copy plan for accessing local register file
     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
 
     const int kThreads = Shared::kThreads;
-    LOG(INFO) << "kThreads: " << kThreads << std::endl
+    LOG(INFO) << std::endl
+              << "kThreads: " << kThreads << std::endl
               << "Shared memory tile shape: [" << Shared::kRows << ", "
               << Shared::kCols << "];" << std::endl
               << "Spatial tile shape: [" << Shared::kRowsPerExec << ", "
@@ -135,10 +354,8 @@ TEST(TestShared2Reg, minimal_shape) {
 
     dim3 dim_grid(1, 1, 1);
     dim3 dim_block(kThreads, 1, 1);
-
     int shm_size = Shared::kNumel * sizeof(Element);
-    test_ldmatrix_s2r<Element, Shared, Reg>
-        <<<dim_grid, dim_block, shm_size>>>();
+    test_ldmatrix3<Element, Shared, Reg><<<dim_grid, dim_block, shm_size>>>();
     cudaDeviceSynchronize();
 }
 

--- a/tests/cpp/cell/test_s2f_copy.cu
+++ b/tests/cpp/cell/test_s2f_copy.cu
@@ -8,12 +8,12 @@ namespace tiledcuda {
 
 using namespace cell;
 using namespace cute;
-
 namespace tl = tile_layout;
 
 namespace testing {
 
 namespace {
+
 /// utility function
 template <typename Element, const int kNumel>
 __device__ void init(Element* data) {
@@ -24,9 +24,7 @@ __device__ void init(Element* data) {
 
 /// utility function
 template <typename Element, const int kRows, const int kCols>
-__device__ void print_tile(const Element* data) {
-    const int delimeter = 64;
-
+__device__ void print_tile(const Element* data, int delimeter = kCols) {
     if (threadIdx.x || blockIdx.x || blockIdx.y) return;
 
     for (int i = 0; i < kRows * kCols; ++i) {
@@ -36,9 +34,46 @@ __device__ void print_tile(const Element* data) {
     printf("\n");
 }
 
-// unittest for copy_s2r
+template <typename Element, int kRows, int kCols>
+__device__ auto cute_ldmatrix(const Element* buf) {
+    // CuTe's configuration for issue a single ldmatrix
+
+    // this setting increases how many threads are used in a CTA
+    using WarpLayout = Layout<Shape<_1, _1, _1>>;
+    // this setting increases how many registers are used in a CTA
+    using ValueLayout = Tile<_16, _16, _16>;
+    // `ldmatrix` loads four 8 x 8 tiles
+    using TiledMma = TiledMMA<MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                              WarpLayout, ValueLayout>;
+    using CopyInst = Copy_Atom<SM75_U32x4_LDSM_N, Element>;
+
+    TiledMma tiled_mma;
+
+    int tid = threadIdx.x;
+
+    auto row_major = tl::RowMajor<kRows, kCols>{};
+    auto tensor = cute::make_tensor(make_smem_ptr(buf), row_major);
+
+    auto tiled_copy = make_tiled_copy_A(CopyInst{}, tiled_mma);
+    auto thrd_copy = tiled_copy.get_thread_slice(tid);
+    auto src = thrd_copy.partition_S(tensor);  // get shared memory partition
+
+    auto thr_mma = tiled_mma.get_thread_slice(tid);
+    // partitioned data tile that is loaded into the current thread's local
+    // register file
+    auto dst = thr_mma.partition_fragment_A(tensor);
+    // make the layout compatible for `tiled_copy`
+    auto dst_view = thrd_copy.retile_D(dst);
+
+    cute::copy(tiled_copy, src(_, _, 0), dst_view(_, _, 0));
+
+    return dst;
+}
+
+// unittest for transferring data from shared memory to thread's local register
+// file using `ldmatrix`
 template <typename Element, typename Shared, typename Reg>
-__global__ void copy_s2r() {
+__global__ void test_ldmatrix_s2r() {
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
     auto* buf = reinterpret_cast<Element*>(buf_);
     init<Element, Shared::kRows * Shared::kCols>(buf);
@@ -47,34 +82,46 @@ __global__ void copy_s2r() {
     print_tile<Element, Shared::kRows, Shared::kCols>(buf);
 #endif
 
+    const float epsilon = 1e-3;
+
     Shared s_tiles(buf);
     Reg r_tile;
-    for (auto i = 0; i < Shared::sc0; ++i) {
-        for (auto j = 0; j < Shared::sc1; ++j) {
-            copy::copy_2d_tile_s2r(s_tiles[make_int2(i, j)], r_tile);
-        }
+    copy::copy_2d_tile_s2r(s_tiles[make_int2(0, 0)], r_tile);
+
+    // ground-truth
+    auto reg_tile = cute_ldmatrix<Element, Shared::kRows, Shared::kCols>(buf);
+    int reg_tile_size = int(size(reg_tile));
+
+    assert(reg_tile_size == Reg::kNumel);
+
+    const half* data1 = reinterpret_cast<const half*>(reg_tile.data());
+    const half* data2 = reinterpret_cast<const half*>(r_tile.data());
+
+    for (int i = 0; i < reg_tile_size; ++i) {
+        assert(__half2float(data1[i]) - __half2float(data2[i]) < epsilon);
     }
 }
+
 }  // namespace
 
-TEST(TestShm2Rf, copy_2d_tile_s2r) {
+TEST(TestShared2Reg, minimal_shape) {
+    // this test case represents the minimum shape that a single warp is used to
+    // execute 1 `ldmatrix`.
     using Element = cutlass::half_t;
 
-    // TODO(haruhi): Test swizzled row major layout for shared memory.
-    // using Swizzled = tl::SwizzledRowMajor<Element, kRows, kCols, 0>;
-    // using SrcLayout = typename Swizzled::SmemLayout;
-
     // configuration for shared memory tile
-    using TemporalExecShared = TileShape<2, 2>;
-    using WarpLayout = TileShape<1, 2>;
+    using TemporalExecShared = TileShape<1, 1>;
+    using WarpLayout = TileShape<1, 1>;
     using ThreadLayout = TileShape<16, 2>;  // fixed when using ldmatrix.
-    using ElemDataTileShared = TileShape<2, 16>;
+    using ElemDataTileShared = TileShape<1, 8>;
     // the final copy plan for accessing shared memory
     using Shared = SharedTile<Element, TemporalExecShared, WarpLayout,
                               ThreadLayout, ElemDataTileShared>;
 
+    static_assert(Shared::sc0 == 1 && Shared::sc1 == 1);
+
     // configuration for register tile
-    using TemporalExecReg = TileShape<2, 2>;
+    using TemporalExecReg = TileShape<1, 1>;
     using ElemDataTileReg = TileShape<1, 8>;  // fixed when using ldmatrix
     // the final copy plan for accessing local register file
     using Reg = RegTile<Element, TemporalExecReg, ElemDataTileReg>;
@@ -90,8 +137,8 @@ TEST(TestShm2Rf, copy_2d_tile_s2r) {
     dim3 dim_block(kThreads, 1, 1);
 
     int shm_size = Shared::kNumel * sizeof(Element);
-    copy_s2r<Element, Shared, Reg><<<dim_grid, dim_block, shm_size>>>();
-
+    test_ldmatrix_s2r<Element, Shared, Reg>
+        <<<dim_grid, dim_block, shm_size>>>();
     cudaDeviceSynchronize();
 }
 


### PR DESCRIPTION
1. bug fix and add unittest for `copy_2d_tile_s2r`
1. resolve https://github.com/TiledTensor/TiledCUDA/issues/35

I think a document is necessary to fully explain the copy details using ldmatrix. Without proper documentation, implementing the fused kernel that correctly reuses data at the register level can be quite hard.