### PR TITLE
(feat): transfer data tile from shared memory to register using ldmatrix.

### DIFF
--- a/include/cell/copy/constants.hpp
+++ b/include/cell/copy/constants.hpp
@@ -1,6 +1,25 @@
 #pragma once
+#include "cell/traits/base.hpp"
+#include "config.hpp"
 
 namespace tiledcuda::cell::copy {
+
+namespace traits = tiledcuda::cell::traits;
+
+// FIXME(haruhi): A quick implementation. Improve in the future.
+// A basic tile shape is a minimal shape to efficiently use the hardware
+// capability.
+template <typename Element, typename Base = traits::TraitsBase<Element>>
+struct BaseTileShape : public Base {
+    static constexpr int elem_per_thread = Base::kNumPerAccess;
+
+    static constexpr int row = 16;
+    // This definition aligns with `ldmatrix`.
+    // When 32 threads in a warp execute `ldmatrix`, they are arranged in a 2x2
+    // thread tile, with each tile containing 8 contiguous threads. Each thread
+    // accesses 128 contiguous bits of data in shared memory.
+    static constexpr int col = elem_per_thread * 2;
+};
 
 enum class CopyInst {
     LoadMat = 0,   // ldmatrix for loading data from shared memory to register.
@@ -14,13 +33,41 @@ enum class RegLayout {
 };
 
 enum class WarpReuse {
-    NoReuse = 0,  // No reuse.
-    Cont = 1,     // Continuous
-    Cir = 2,      // Circular
-    RowCont = 3,  // RowWiseContinuouslyReuse
-    RowCir = 4,   // RowWiseCircularlyReuse
-    ColCont = 5,  // ColWiseContinuouslyReuse
-    ColCir = 6    // ColWiseCircularlyReuse
+    // TODO(haruhi): It seems that Cir/RowReuseCir/ColReuseCir are not ncessary,
+    // thus the reuse mode can be simplified.
+    // data are evenly partitioned to be loaded by warps.
+    Cont = 0,          // all warps continuously load data, no reuse
+    Cir = 1,           // all warps circularly load data, no reuse
+    RowReuseCont = 2,  // Row-wise even reuse, warps in the same row
+                       // repeatedly load the same data
+    RowReuseCir = 3,   // Row-wise circular reuse
+    ColReuseCont = 4,  // Column-wise even reuse, warps in the same column
+                       // repeatedly load the same data
+    ColReuseCir = 5    // Column-wise circular reuse
 };
+
+template <typename Element, const int rows, const int warps_per_row,
+          const WarpReuse mode>
+DEVICE static constexpr int row_exec_count() {
+    switch (mode) {
+        case WarpReuse::ColReuseCont:
+        case WarpReuse::ColReuseCir:
+            return rows / BaseTileShape<Element>::row;
+        default:  // Cont, Cir, RowReuseCont, RowReuseCir hit this case.
+            return rows / BaseTileShape<Element>::row / warps_per_row;
+    }
+}
+
+template <typename Element, const int cols, const int warps_per_col,
+          const WarpReuse mode>
+DEVICE static constexpr int col_exec_count() {
+    switch (mode) {
+        case WarpReuse::RowReuseCont:
+        case WarpReuse::RowReuseCir:
+            return cols / BaseTileShape<Element>::col;
+        default:  // Cont, Cir, ColReuseCont, ColReuseCir hit this case.
+            return cols / BaseTileShape<Element>::col / warps_per_col;
+    }
+}
 
 }  // namespace tiledcuda::cell::copy

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -2,57 +2,203 @@
 
 #include "cell/copy/constants.hpp"
 #include "types/mod.hpp"
+#include "util/print.hpp"
 
 namespace tiledcuda::cell::copy {
 
-namespace detail {
+namespace {  // helper functions
+template <typename Element>
+DEVICE void ldmatrix(const Element* src, Element* dst) {
+    uint32_t* reg = reinterpret_cast<uint32_t*>(dst);
+    uint32_t smem_addr = __cvta_generic_to_shared(src);
+    asm volatile(
+        "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+        : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+        : "r"(smem_addr));
+}
 
-// functor to copy data from shared memory to register file.
-template <typename Shared, typename Reg, typename WarpLayout,
+/// @brief the warp row that the current thread belongs to, based on the warp
+/// layout.
+template <typename WarpLayout>
+DEVICE int warp_row_id() {
+    /*
+     * Example1: suppose the warp layout is RowMajor<2,2>, like this:
+     * |-|-----|-----|
+     * |0|warp0|warp1|
+     * |-|-----|-----|
+     * |1|warp2|warp3|
+     * |-|-----|-----|, and the threadIdx is 67, then the warp row is 1.
+     *
+     * Example2: suppose the warp layout is ColMajor<2,2>, like this:
+     * |-|-----|-----|
+     * |0|warp0|warp2|
+     * |-|-----|-----|
+     * |1|warp1|warp3|
+     * |-|-----|-----|, and the threadIdx is 67, then the warp row is 0.
+     */
+    int wid = threadIdx.x / warpSize;
+    int warp_row = tl::is_rowmajor<WarpLayout> ? wid / tl::num_cols<WarpLayout>
+                                               : wid % tl::num_rows<WarpLayout>;
+    return warp_row;
+}
+
+/// @brief: Returns the warp col that the current thread belongs to, based on
+/// the warp layout.
+template <typename WarpLayout>
+DEVICE int warp_col_id() {
+    /*
+     * Example1: suppose the warp layout is RowMajor<2,2>, like this:
+     * |-----|-----|
+     * |  0  |  1  |
+     * |-----|-----|
+     * |warp0|warp1|
+     * |-----|-----|
+     * |warp2|warp3|
+     * |-----|-----|, and the threadIdx is 67, then the warp col is 0.
+     *
+     * Example2: suppose the warp layout is ColMajor<2,2>, like this:
+     * |-----|-----|
+     * |  0  |  1  |
+     * |-----|-----|
+     * |warp0|warp2|
+     * |-----|-----|
+     * |warp1|warp3|
+     * |-----|-----|, and the threadIdx is 67, then the warp row is 1.
+     */
+    int wid = threadIdx.x / warpSize;
+    int warp_col = tl::is_rowmajor<WarpLayout> ? wid % tl::num_cols<WarpLayout>
+                                               : wid / tl::num_rows<WarpLayout>;
+    return warp_col;
+}
+
+}  // namespace
+
+/// @brief The functor that copys data from shared memory to register file.
+///        Shared memory tile is not declared as template parameter, because we
+///        assume it is computed from runtime value by `TileIterator`.
+template <typename Reg,
+          typename WarpLayout,  //
+          WarpReuse kMode,      //
           CopyInst kCopyInst>
-struct CopyShared2Reg {
-    DEVICE void operator()(const Shared& src, Reg& dst, WarpReuse kMode);
+struct SharedToRegLoader {
+    template <typename Shared>
+    DEVICE void operator()(const Shared& src, Reg& dst);
 };
 
-// partial specialization for ldmatrix
-template <typename Shared, typename Reg, typename WarpLayout>
-struct CopyShared2Reg<Shared, Reg, WarpLayout, CopyInst::LoadMat> {
-    DEVICE void operator()(const Shared& src, Reg& dst, WarpReuse kMode) {
-        // implement this
+template <typename Reg_, typename WarpLayout_>
+struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
+                         CopyInst::LoadMat> {
+    using Reg = Reg_;
+    using WarpLayout = WarpLayout_;
+    static constexpr WarpReuse kMode = WarpReuse::RowReuseCont;
+
+    using DType = typename Reg::DType;
+
+    template <typename Shared>
+    DEVICE void operator()(const Shared& src, Reg& dst) {
+        static_assert(std::is_same<typename Shared::DType, DType>::value,
+                      "The data type of Shared and Reg must be the same.");
+        // print_tile(src.data(), src.layout());
+
+        static_assert(Shared::kRows % tl::num_rows<WarpLayout> == 0,
+                      "The current implementation requires Shared::kRows must "
+                      "be divisible by tl::num_rows<WarpLayout>");
+        static_assert(Shared::kCols % tl::num_cols<WarpLayout> == 0,
+                      "The current implementation requires Shared::kCols must "
+                      "be divisible by tl::num_cols<WarpLayout>");
+
+        // how many times `BaseTile` are executed alongs rows and cols by the
+        // current thread
+        const int row_exec = row_exec_count<DType, Shared::kRows,
+                                            tl::num_rows<WarpLayout>, kMode>();
+        const int col_exec = col_exec_count<DType, Shared::kCols,
+                                            tl::num_cols<WarpLayout>, kMode>();
+
+        // Tile shape for a single warp
+        using WarpTileShape = TileShape<row_exec * BaseTileShape<DType>::row,
+                                        col_exec * BaseTileShape<DType>::col>;
+
+        int warp_row = warp_row_id<WarpLayout>();
+        int warp_col = warp_col_id<WarpLayout>();
+
+        if (thread(57)) {
+            // printf("\nwarp shape :");
+            // print(WarpTileShape{});
+
+            printf("\n\nrow_exec: %d, col_exec: %d\n", row_exec, col_exec);
+            printf("warp_row: %d, warp_col: %d\n", warp_row, warp_col);
+        }
+
+        const DType* src_ptr = src.data();
+        DType* dst_ptr = dst.mutable_data();
+
+        for (int i = 0; i < row_exec; ++i) {
+            for (int j = 0; j < col_exec; ++j) {
+                ldmatrix(src_ptr, dst_ptr);
+
+                dst_ptr += BaseTileShape<DType>::elem_per_thread;
+                break;
+            }
+            break;
+        }
     }
 };
 
+template <typename Reg_, typename WarpLayout_>
+struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::ColReuseCont,
+                         CopyInst::LoadMat> {
+    using Reg = Reg_;
+    using WarpLayout = WarpLayout_;
+    static constexpr WarpReuse kMode = WarpReuse::ColReuseCont;
+
+    using DType = typename Reg::DType;
+
+    template <typename Shared>
+    DEVICE void operator()(const Shared& src, Reg& dst) {
+        static_assert(std::is_same<typename Shared::DType, DType>::value,
+                      "The data type of Shared and Reg must be the same.");
+
+        static_assert(Shared::kRows % tl::num_rows<WarpLayout> == 0,
+                      "The current implementation requires Shared::kRows must "
+                      "be divisible by tl::num_rows<WarpLayout>");
+        static_assert(Shared::kCols % tl::num_cols<WarpLayout> == 0,
+                      "The current implementation requires Shared::kCols must "
+                      "be divisible by tl::num_cols<WarpLayout>");
+
+        int row_exec = row_exec_count<DType, Shared::kRows,
+                                      tl::num_rows<WarpLayout>, kMode>();
+        int col_exec = col_exec_count<DType, Shared::kCols,
+                                      tl::num_cols<WarpLayout>, kMode>();
+
+        int warp_row = warp_row_id<WarpLayout>();
+        int warp_col = warp_col_id<WarpLayout>();
+
+        if (thread0()) {
+            printf("\n\trow_exec: %d, col_exec: %d\n", row_exec, col_exec);
+        }
+    }
+};
+
+namespace detail {
 // functor to copy data from shared memory to register file.
 template <typename Reg, typename Shared, typename InstShape,
           RegLayout kRegLayout, CopyInst kCopyInst>
-struct CopyReg2Shared {
+struct RegToShared {
     DEVICE void operator()(const Reg& src, Shared& dst);
 };
 
 // partial specialization for wmma 16x16x16, and LDSM32
 template <typename Reg, typename Shared>
-struct CopyReg2Shared<Reg, Shared, InstShape<16, 16, 16>, RegLayout::TileWMMA,
-                      CopyInst::LoadS32> {
+struct RegToShared<Reg, Shared, InstShape<16, 16, 16>, RegLayout::TileWMMA,
+                   CopyInst::LoadS32> {
     DEVICE void operator()(const Reg& src, Shared& dst) {}
 };
 }  // namespace detail
 
-/// a warper function for the situation that `Shared` are computed from some
-/// runtime value.
-template <typename Shared, typename Reg, typename WarpLayout>
-DEVICE void copy_tile_s2r(const Shared& src, Reg& dst, const WarpLayout& layout,
-                          WarpReuse kMode) {
-    using Copy =
-        detail::CopyShared2Reg<Shared, Reg, WarpLayout, CopyInst::LoadMat>;
-
-    Copy copy;
-    copy(src, dst, kMode);
-}
-
 template <typename Reg, typename Shared>
 DEVICE void copy_tile_r2s(const Reg& src, Shared& dst) {
-    using Copy = detail::CopyReg2Shared<Reg, Shared, InstShape<16, 16, 16>,
-                                        RegLayout::TileWMMA, CopyInst::LoadS32>;
+    using Copy = detail::RegToShared<Reg, Shared, InstShape<16, 16, 16>,
+                                     RegLayout::TileWMMA, CopyInst::LoadS32>;
     Copy copy;
     copy(src, dst);
 }

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -18,7 +18,7 @@ DEVICE void ldmatrix(const Element* src, Element* dst) {
 }
 
 /// @brief the warp row that the current thread belongs to, based on the warp
-/// layout.
+///        layout.
 template <typename WarpLayout>
 DEVICE int warp_row_id() {
     /*
@@ -43,7 +43,7 @@ DEVICE int warp_row_id() {
 }
 
 /// @brief: Returns the warp col that the current thread belongs to, based on
-/// the warp layout.
+///         the warp layout.
 template <typename WarpLayout>
 DEVICE int warp_col_id() {
     /*
@@ -72,15 +72,15 @@ DEVICE int warp_col_id() {
 }
 
 /// @brief This function returns the lane row of the current thread within a
-/// warp. We assume that the threads in a warp are arranged as follows (a 16 x 2
-/// column-major):
-/*     |  | 0 |  1|
- *     |--|---|---|
- *     |0 | 0 | 16|
- *     |1 | 2 | 17|
- *     |2 | 4 | 18|
- *     |  |...|...|
- *     |15| 15| 31|
+///        warp. We assume that the threads in a warp are arranged as follows (a
+///        16 x 2 column-major):
+/*         |  | 0 |  1|
+ *         |--|---|---|
+ *         |0 | 0 | 16|
+ *         |1 | 2 | 17|
+ *         |2 | 4 | 18|
+ *         |  |...|...|
+ *         |15| 15| 31|
  *  Example: if threadIdx is 43, then its lane row is 8, lane col is 0.
  */
 DEVICE int lane_row_id() {
@@ -89,10 +89,57 @@ DEVICE int lane_row_id() {
 }
 
 /// @brief This function returns the lane col of the current thread within a
-/// warp. We assume that the threads in a warp are arranged as explained above.
+///        warp. We assume that the threads in a warp are arranged as explained
+///        above.
 DEVICE int lane_col_id() {
     int lane_id = threadIdx.x % warpSize;  // thread index inside a warp
     return lane_id / 16;
+}
+
+template <const WarpReuse kMode, typename Shared, typename WarpLayout>
+DEVICE int get_warp_offset() {
+    constexpr static bool row_major = Shared::kIsRowMajor;
+
+    int offset = 0;
+    switch (kMode) {
+        case WarpReuse::RowReuseCont: {
+            // In the `RowReuseCont` mode, warps in a same row repeatedly load
+            // the same data, and each warp loads a continuous chunks of data.
+
+            // Tile shape for a single warp
+            constexpr static int warp_shape_row =
+                Shared::kRows / tl::num_rows<WarpLayout>;
+            constexpr static int warp_rstride =
+                row_major ? Shared::kRowStride * warp_shape_row
+                          : warp_shape_row;
+
+            int warp_row = warp_row_id<WarpLayout>();
+            offset = warp_row * warp_rstride;
+            break;
+        }
+        case WarpReuse::ColReuseCont: {
+            // In the `ColReuseCont` mode, warps in a same column repeatedly
+            // load the same data, and each warp loads a continuous chunks of
+            // data.
+
+            // Tile shape for a single warp
+            constexpr static int warp_shape_col =
+                Shared::kCols / tl::num_cols<WarpLayout>;
+            constexpr static int warp_cstride =
+                row_major ? warp_shape_col
+                          : Shared::kColStride * warp_shape_col;
+
+            int warp_col = warp_col_id<WarpLayout>();
+            offset = warp_col * warp_cstride;
+            break;
+        }
+        default: {
+            // simulate "the not implemented error"
+            assert(false && "Not implemented yet.");
+            break;
+        }
+    }
+    return offset;
 }
 
 }  // namespace
@@ -109,17 +156,10 @@ struct SharedToRegLoader {
     DEVICE void operator()(const Shared& src, Reg& dst);
 };
 
-/// @brief In the `RowReuseCont` mode, warps in the same row repeatedly load the
-///        same data, and each warp loads a continuous chunks of data.
-/// @tparam Reg_: register tile
-/// @tparam WarpLayout_: warp arrangement, row-major or column-major
-template <typename Reg_, typename WarpLayout_>
-struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
-                         CopyInst::LoadMat> {
+template <typename Reg_, typename WarpLayout_, const WarpReuse kMode>
+struct SharedToRegLoader<Reg_, WarpLayout_, kMode, CopyInst::LoadMat> {
     using Reg = Reg_;
     using WarpLayout = WarpLayout_;
-    static constexpr WarpReuse kMode = WarpReuse::RowReuseCont;
-
     using DType = typename Reg::DType;
 
     template <typename Shared>
@@ -134,28 +174,21 @@ struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
                       "be divisible by tl::num_cols<WarpLayout>");
 
         const bool row_major = Shared::kIsRowMajor;
-        // get data pointer
-        const DType* src_ptr = src.data();
-        DType* dst_ptr = dst.mutable_data();
+        const DType* src_ptr = src.data();    // pointer for shared memory tile
+        DType* dst_ptr = dst.mutable_data();  // pointer for register tile
 
-        // how many times `BaseTile` are executed alongs rows and cols by the
-        // current thread
-        const int row_exec = row_exec_count<DType, Shared::kRows,
-                                            tl::num_rows<WarpLayout>, kMode>();
-        const int col_exec = col_exec_count<DType, Shared::kCols,
-                                            tl::num_cols<WarpLayout>, kMode>();
+        // how many times a `BaseTile` is executed along the row and column
+        // direction.
+        int row_exec = row_exec_count<DType, Shared::kRows,
+                                      tl::num_rows<WarpLayout>, kMode>();
+        int col_exec = col_exec_count<DType, Shared::kCols,
+                                      tl::num_cols<WarpLayout>, kMode>();
 
-        // Tile shape for a single warp
-        const int warp_shape_row = Shared::kRows / tl::num_rows<WarpLayout>;
-        const int warp_rstride =
-            row_major ? Shared::kRowStride * warp_shape_row : warp_shape_row;
+        // 1. advance the pointer to input data to the current warp according to
+        // warp reuse mode.
+        src_ptr += get_warp_offset<kMode, Shared, WarpLayout>();
 
-        // 1. advance the pointer to data to the current warp.
-        int warp_row = warp_row_id<WarpLayout>();
-        int offset = warp_row * warp_rstride;
-        src_ptr += offset;
-
-        // strides to iterate over each 16x16 base tile.
+        // strides to iterate over each 16x128-bits base tile.
         const int tile_rstride =  // row stride for a base tile
             row_major ? BaseTileShape<DType>::row * Shared::kRowStride
                       : BaseTileShape<DType>::row;
@@ -186,47 +219,10 @@ struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
                 dst_ptr += BaseTileShape<DType>::elem_per_thread;
             }
         }
-
         dst.dump_value();
     }
 };
 
-template <typename Reg_, typename WarpLayout_>
-struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::ColReuseCont,
-                         CopyInst::LoadMat> {
-    using Reg = Reg_;
-    using WarpLayout = WarpLayout_;
-    static constexpr WarpReuse kMode = WarpReuse::ColReuseCont;
-
-    using DType = typename Reg::DType;
-
-    template <typename Shared>
-    DEVICE void operator()(const Shared& src, Reg& dst) {
-        static_assert(std::is_same<typename Shared::DType, DType>::value,
-                      "The data type of Shared and Reg must be the same.");
-
-        static_assert(Shared::kRows % tl::num_rows<WarpLayout> == 0,
-                      "The current implementation requires Shared::kRows must "
-                      "be divisible by tl::num_rows<WarpLayout>");
-        static_assert(Shared::kCols % tl::num_cols<WarpLayout> == 0,
-                      "The current implementation requires Shared::kCols must "
-                      "be divisible by tl::num_cols<WarpLayout>");
-
-        int row_exec = row_exec_count<DType, Shared::kRows,
-                                      tl::num_rows<WarpLayout>, kMode>();
-        int col_exec = col_exec_count<DType, Shared::kCols,
-                                      tl::num_cols<WarpLayout>, kMode>();
-
-        int warp_row = warp_row_id<WarpLayout>();
-        int warp_col = warp_col_id<WarpLayout>();
-
-        if (thread0()) {
-            printf("\n\trow_exec: %d, col_exec: %d\n", row_exec, col_exec);
-        }
-    }
-};
-
-namespace detail {
 // functor to copy data from shared memory to register file.
 template <typename Reg, typename Shared, typename InstShape,
           RegLayout kRegLayout, CopyInst kCopyInst>
@@ -240,12 +236,11 @@ struct RegToShared<Reg, Shared, InstShape<16, 16, 16>, RegLayout::TileWMMA,
                    CopyInst::LoadS32> {
     DEVICE void operator()(const Reg& src, Shared& dst) {}
 };
-}  // namespace detail
 
 template <typename Reg, typename Shared>
 DEVICE void copy_tile_r2s(const Reg& src, Shared& dst) {
-    using Copy = detail::RegToShared<Reg, Shared, InstShape<16, 16, 16>,
-                                     RegLayout::TileWMMA, CopyInst::LoadS32>;
+    using Copy = RegToShared<Reg, Shared, InstShape<16, 16, 16>,
+                             RegLayout::TileWMMA, CopyInst::LoadS32>;
     Copy copy;
     copy(src, dst);
 }

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -13,7 +13,7 @@ DEVICE void ldmatrix(const Element* src, Element* dst) {
     uint32_t smem_addr = __cvta_generic_to_shared(src);
     asm volatile(
         "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
-        : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+        : "=r"(reg[0]), "=r"(reg[2]), "=r"(reg[1]), "=r"(reg[3])
         : "r"(smem_addr));
 }
 
@@ -71,6 +71,30 @@ DEVICE int warp_col_id() {
     return warp_col;
 }
 
+/// @brief This function returns the lane row of the current thread within a
+/// warp. We assume that the threads in a warp are arranged as follows (a 16 x 2
+/// column-major):
+/*     |  | 0 |  1|
+ *     |--|---|---|
+ *     |0 | 0 | 16|
+ *     |1 | 2 | 17|
+ *     |2 | 4 | 18|
+ *     |  |...|...|
+ *     |15| 15| 31|
+ *  Example: if threadIdx is 43, then its lane row is 8, lane col is 0.
+ */
+DEVICE int lane_row_id() {
+    int lane_id = threadIdx.x % warpSize;  // thread index inside a warp
+    return lane_id % 16;
+}
+
+/// @brief This function returns the lane col of the current thread within a
+/// warp. We assume that the threads in a warp are arranged as explained above.
+DEVICE int lane_col_id() {
+    int lane_id = threadIdx.x % warpSize;  // thread index inside a warp
+    return lane_id / 16;
+}
+
 }  // namespace
 
 /// @brief The functor that copys data from shared memory to register file.
@@ -85,6 +109,10 @@ struct SharedToRegLoader {
     DEVICE void operator()(const Shared& src, Reg& dst);
 };
 
+/// @brief In the `RowReuseCont` mode, warps in the same row repeatedly load the
+///        same data, and each warp loads a continuous chunks of data.
+/// @tparam Reg_: register tile
+/// @tparam WarpLayout_: warp arrangement, row-major or column-major
 template <typename Reg_, typename WarpLayout_>
 struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
                          CopyInst::LoadMat> {
@@ -98,14 +126,17 @@ struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
     DEVICE void operator()(const Shared& src, Reg& dst) {
         static_assert(std::is_same<typename Shared::DType, DType>::value,
                       "The data type of Shared and Reg must be the same.");
-        // print_tile(src.data(), src.layout());
-
         static_assert(Shared::kRows % tl::num_rows<WarpLayout> == 0,
                       "The current implementation requires Shared::kRows must "
                       "be divisible by tl::num_rows<WarpLayout>");
         static_assert(Shared::kCols % tl::num_cols<WarpLayout> == 0,
                       "The current implementation requires Shared::kCols must "
                       "be divisible by tl::num_cols<WarpLayout>");
+
+        const bool row_major = Shared::kIsRowMajor;
+        // get data pointer
+        const DType* src_ptr = src.data();
+        DType* dst_ptr = dst.mutable_data();
 
         // how many times `BaseTile` are executed alongs rows and cols by the
         // current thread
@@ -115,32 +146,48 @@ struct SharedToRegLoader<Reg_, WarpLayout_, WarpReuse::RowReuseCont,
                                             tl::num_cols<WarpLayout>, kMode>();
 
         // Tile shape for a single warp
-        using WarpTileShape = TileShape<row_exec * BaseTileShape<DType>::row,
-                                        col_exec * BaseTileShape<DType>::col>;
+        const int warp_shape_row = Shared::kRows / tl::num_rows<WarpLayout>;
+        const int warp_rstride =
+            row_major ? Shared::kRowStride * warp_shape_row : warp_shape_row;
 
+        // 1. advance the pointer to data to the current warp.
         int warp_row = warp_row_id<WarpLayout>();
-        int warp_col = warp_col_id<WarpLayout>();
+        int offset = warp_row * warp_rstride;
+        src_ptr += offset;
 
-        if (thread(57)) {
-            // printf("\nwarp shape :");
-            // print(WarpTileShape{});
+        // strides to iterate over each 16x16 base tile.
+        const int tile_rstride =  // row stride for a base tile
+            row_major ? BaseTileShape<DType>::row * Shared::kRowStride
+                      : BaseTileShape<DType>::row;
+        const int tile_cstride =  // col stride for a base tile
+            row_major ? BaseTileShape<DType>::col
+                      : BaseTileShape<DType>::col * Shared::kColStride;
 
-            printf("\n\nrow_exec: %d, col_exec: %d\n", row_exec, col_exec);
-            printf("warp_row: %d, warp_col: %d\n", warp_row, warp_col);
-        }
+        // row stride and col stride for a thread in a warp
+        const int lane_rstride = row_major ? Shared::kRowStride : 8;
+        const int lane_cstride = row_major ? 8 : Shared::kColStride;
 
-        const DType* src_ptr = src.data();
-        DType* dst_ptr = dst.mutable_data();
+        int lane_row = lane_row_id();
+        int lane_col = lane_col_id();
 
+        const DType* data;
         for (int i = 0; i < row_exec; ++i) {
             for (int j = 0; j < col_exec; ++j) {
-                ldmatrix(src_ptr, dst_ptr);
+                // 2. advance pointer to the 16x16 base tile indexed by (i, j).
+                data = src_ptr + (i * tile_rstride + j * tile_cstride);
+                // 3. advance the pointer to data accessed by the current thread
+                // inside a 16x16 base tile.
+                data += (lane_row * lane_rstride + lane_col * lane_cstride);
 
+                // issue the hardware-backed memory access instruction
+                ldmatrix(data, dst_ptr);
+
+                // advance the pointer to store the next 16x16 base tile.
                 dst_ptr += BaseTileShape<DType>::elem_per_thread;
-                break;
             }
-            break;
         }
+
+        dst.dump_value();
     }
 };
 

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -30,6 +30,8 @@ class SharedTile {
 
     DEVICE const DType* data() const { return data_; }
 
+    HOST_DEVICE const Layout& layout() const { return layout_; }
+
     // for write access
     DEVICE DType& operator()(int x, int y) { return data_[layout_(x, y)]; }
 

--- a/include/util/print.hpp
+++ b/include/util/print.hpp
@@ -31,7 +31,7 @@ DEVICE void print_tile(const cutlass::half_t* data, const Layout& layout) {
 
     for (int i = 0; i < tl::num_rows<Layout>; ++i) {
         for (int j = 0; j < tl::num_cols<Layout>; ++j) {
-            printf("%.0f, ", __half2float(data_[layout(i, j)]));
+            printf("%.1f, ", __half2float(data_[layout(i, j)]));
         }
         printf("\n");
     }

--- a/include/util/print.hpp
+++ b/include/util/print.hpp
@@ -31,7 +31,7 @@ DEVICE void print_tile(const cutlass::half_t* data, const Layout& layout) {
 
     for (int i = 0; i < tl::num_rows<Layout>; ++i) {
         for (int j = 0; j < tl::num_cols<Layout>; ++j) {
-            printf("%.1f, ", __half2float(data_[layout(i, j)]));
+            printf("%.0f, ", __half2float(data_[layout(i, j)]));
         }
         printf("\n");
     }

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -14,7 +14,7 @@ namespace {
 
 template <typename Element>
 __device__ void init_value(Element* data, int numel) {
-    for (int i = 0; i < numel; ++i) data[i] = static_cast<Element>(i);
+    for (int i = 0; i < numel; ++i) data[i] = static_cast<Element>(i % 2048);
 }
 
 template <typename Element, typename Shared, typename Reg, typename Copy>
@@ -55,28 +55,28 @@ TEST(TestShared2Reg, operand_A) {
     cudaDeviceSynchronize();
 }
 
-// TEST(TestShared2Reg, operand_B) {
-//     // the load mode for loading operand B in gemm
-//     using Element = cutlass::half_t;
+TEST(TestShared2Reg, operand_B) {
+    // the load mode for loading operand B in gemm
+    using Element = cutlass::half_t;
 
-//     using WarpLayout = tl::RowMajor<2, 2>;
-//     const int kThreads = tl::get_numel<WarpLayout> * 32;
+    using WarpLayout = tl::RowMajor<2, 2>;
+    const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-//     using Shared = SharedTile<Element, tl::RowMajor<64, 32>>;
-//     using Reg = RegTile<Element, tl::RowMajor<2, 12>>;
+    using Shared = SharedTile<Element, tl::RowMajor<64, 32>>;
+    using Reg = RegTile<Element, tl::RowMajor<4, 8>>;
 
-//     using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont,
-//                                    CopyInst::LoadMat>;
-//     Copy copy;
+    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont,
+                                   CopyInst::LoadMat>;
+    Copy copy;
 
-//     dim3 dim_grid(1, 1, 1);
-//     dim3 dim_block(kThreads, 1, 1);
-//     int shm_size = Shared::kNumel * sizeof(Element);
+    dim3 dim_grid(1, 1, 1);
+    dim3 dim_block(kThreads, 1, 1);
+    int shm_size = Shared::kNumel * sizeof(Element);
 
-//     run_test<Element, Shared, Reg, Copy>
-//         <<<dim_grid, dim_block, shm_size>>>(copy);
-//     cudaDeviceSynchronize();
-// }
+    run_test<Element, Shared, Reg, Copy>
+        <<<dim_grid, dim_block, shm_size>>>(copy);
+    cudaDeviceSynchronize();
+}
 
 }  // namespace testing
 }  // namespace tiledcuda

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -62,7 +62,8 @@ TEST(TestShared2Reg, operand_B) {
     using WarpLayout = tl::RowMajor<2, 2>;
     const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-    using Shared = SharedTile<Element, tl::RowMajor<64, 32>>;
+    // a 32x64 row-major shared tile is equivalent to a 64x32 col-major tile
+    using Shared = SharedTile<Element, tl::RowMajor<32, 64>>;
     using Reg = RegTile<Element, tl::RowMajor<4, 8>>;
 
     using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont,

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -64,6 +64,7 @@ TEST(TestShared2Reg, operand_B) {
 
     // a 32x64 row-major shared tile is equivalent to a 64x32 col-major tile
     using Shared = SharedTile<Element, tl::RowMajor<32, 64>>;
+
     using Reg = RegTile<Element, tl::RowMajor<4, 8>>;
 
     using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont,

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -7,6 +7,7 @@
 namespace tiledcuda {
 
 using namespace cell;
+using namespace copy;
 namespace tl = tile_layout;
 
 namespace {
@@ -17,7 +18,7 @@ __device__ void init_value(Element* data, int numel) {
 }
 
 template <typename Element, typename Shared, typename Reg, typename Copy>
-__global__ void test1(Copy& copy) {
+__global__ void run_test(Copy& copy) {
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
     auto* buf = reinterpret_cast<Element*>(buf_);
     init_value(buf, Shared::kNumel);
@@ -25,32 +26,57 @@ __global__ void test1(Copy& copy) {
     Shared s_tile(buf);
     Reg r_tile;
 
-    copy(s_tile, r_tile, copy::WarpReuse::RowCir);
+    copy(s_tile, r_tile);
 }
 
 }  // namespace
 
 namespace testing {
 
-TEST(TestShared2Reg, shape1) {
+TEST(TestShared2Reg, operand_A) {
+    // the load mode for loading operand B in gemm
     using Element = cutlass::half_t;
 
-    using WarpLayout = TileShape<2, 2>;
-    const int kThreads = get_numel<WarpLayout> * 32;
+    using WarpLayout = tl::RowMajor<2, 2>;
+    const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-    using Shared = SharedTile<Element, tl::RowMajor<32, 48>>;
-    using Reg = RegTile<Element, tl::RowMajor<2, 12>>;
-    using Copy = copy::detail::CopyShared2Reg<Shared, Reg, WarpLayout,
-                                              copy::CopyInst::LoadMat>;
+    using Shared = SharedTile<Element, tl::RowMajor<64, 32>>;
+    using Reg = RegTile<Element, tl::RowMajor<4, 8>>;
+    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::RowReuseCont,
+                                   CopyInst::LoadMat>;
     Copy copy;
 
     dim3 dim_grid(1, 1, 1);
     dim3 dim_block(kThreads, 1, 1);
     int shm_size = Shared::kNumel * sizeof(Element);
 
-    test1<Element, Shared, Reg, Copy><<<dim_grid, dim_block, shm_size>>>(copy);
+    run_test<Element, Shared, Reg, Copy>
+        <<<dim_grid, dim_block, shm_size>>>(copy);
     cudaDeviceSynchronize();
 }
+
+// TEST(TestShared2Reg, operand_B) {
+//     // the load mode for loading operand B in gemm
+//     using Element = cutlass::half_t;
+
+//     using WarpLayout = tl::RowMajor<2, 2>;
+//     const int kThreads = tl::get_numel<WarpLayout> * 32;
+
+//     using Shared = SharedTile<Element, tl::RowMajor<64, 32>>;
+//     using Reg = RegTile<Element, tl::RowMajor<2, 12>>;
+
+//     using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont,
+//                                    CopyInst::LoadMat>;
+//     Copy copy;
+
+//     dim3 dim_grid(1, 1, 1);
+//     dim3 dim_block(kThreads, 1, 1);
+//     int shm_size = Shared::kNumel * sizeof(Element);
+
+//     run_test<Element, Shared, Reg, Copy>
+//         <<<dim_grid, dim_block, shm_size>>>(copy);
+//     cudaDeviceSynchronize();
+// }
 
 }  // namespace testing
 }  // namespace tiledcuda


### PR DESCRIPTION
resolve https://github.com/TiledTensor/TiledCUDA/issues/52 resolve https://github.com/TiledTensor/TiledCUDA/issues/44 resolve https://github.com/TiledTensor/TiledCUDA/issues/31

- [x] support warp reuse mode for loading operand A in gemm
- [x] support warp reuse mode for loading operand B in gemm
- [x] test on the gemm example.

Since the store from register to shared memory is not yet complete, a unit test to ensure correctness is not included in this PR. This will be added later.