### PR TITLE
fix(unittest): bug fix for tensor core gemm.

### DIFF
--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -380,7 +380,7 @@ struct RegToSharedStorer<Reg_, WarpLayout_, RegLayout::WMMA_m16n16k16,
         const int tile_cstride = row_major ? 16 : 16 * Shared::kColStride;
 
         // Given the lane position of the current thread, calculate the strides
-        // needed to address the data within the 16x128-bit `Base Tile` for the
+        // needed to address the data within the 16x128-bit `BaseTile` for the
         // current thread.
         const int lane_rstride = row_major ? Shared::kRowStride : stride;
         const int lane_cstride = row_major ? stride : Shared::kColStride;


### PR DESCRIPTION
1. Fixed a small bug where slicing the K-dimension used a chunk size smaller than K.
2. Made a slight improvement to the numeric check for half-precision GEMM by using the average absolute difference instead of a single difference, as the latter is unstable.
3. Unified the printing style.