### PR TITLE
fix(core): Bug fix for load column-major register tile for tensor core gemm.

### DIFF
--- a/include/cell/copy/constants.hpp
+++ b/include/cell/copy/constants.hpp
@@ -11,19 +11,6 @@ enum class CopyInst {
     LoadS128 = 3   // ldsm128 for loading 128-bit data from shared memory.
 };
 
-// FIXME(haruhi): A quick implementation. Consider whether this enum should be
-// coupled with RegTile.
-enum class RegLayout {
-    FMA = 0,  // Tile layout for FMA.
-
-    // Refer to this slide for details on how data is distributed in each
-    // thread's local register after the TCU's WMMA operation:
-    // https://developer.download.nvidia.com/video/gputechconf/gtc/2020/
-    // presentations/s21745-developing-cuda-kernels-to-push-tensor-cores-to-the-absolute-limit-on-nvidia-a100.pdf
-    // WMMA shape is "m16n16k16
-    WMMA_m16n16k16 = 1,
-};
-
 enum class WarpReuse {
     // TODO(haruhi): It seems that Cir/RowReuseCir/ColReuseCir are not ncessary,
     // thus the reuse mode can be simplified.

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -30,9 +30,18 @@ DEVICE int warp_row_id() {
      * |-|-----|-----|, and the threadIdx is 67, then the warp row is 0.
      */
     int wid = threadIdx.x / warpSize;
-    int warp_row = tl::is_rowmajor<WarpLayout> ? wid / tl::num_cols<WarpLayout>
-                                               : wid % tl::num_rows<WarpLayout>;
-    return warp_row;
+
+    // FIXME(haruhi): The switch-case structure is currently inelegant.
+    // Consider refining the code structure using more appropriate methods, such
+    // as partial specialization.
+    switch (tl::layout_type<WarpLayout>) {
+        case tl::Layout::RowMajor:
+            return wid / tl::num_cols<WarpLayout>;
+        case tl::Layout::ColMajor:
+            return wid % tl::num_rows<WarpLayout>;
+        default:
+            assert(false && "Not implemented yet.");
+    }
 }
 
 // @brief: Returns the warp col that the current thread belongs to, based on
@@ -59,9 +68,18 @@ DEVICE int warp_col_id() {
      * |-----|-----|, and the threadIdx is 67, then the warp row is 1.
      */
     int wid = threadIdx.x / warpSize;
-    int warp_col = tl::is_rowmajor<WarpLayout> ? wid % tl::num_cols<WarpLayout>
-                                               : wid / tl::num_rows<WarpLayout>;
-    return warp_col;
+
+    // FIXME(haruhi): The switch-case structure is currently inelegant.
+    // Consider refining the code structure using more appropriate methods, such
+    // as partial specialization.
+    switch (tl::layout_type<WarpLayout>) {
+        case tl::Layout::RowMajor:
+            return wid % tl::num_cols<WarpLayout>;
+        case tl::Layout::ColMajor:
+            return wid / tl::num_rows<WarpLayout>;
+        default:
+            assert(false && "Not implemented yet.");
+    }
 }
 
 // @brief This function returns the lane row of the current thread within a
@@ -79,8 +97,18 @@ DEVICE int warp_col_id() {
 template <typename Layout>
 DEVICE int lane_row_id() {
     int lane_id = threadIdx.x % warpSize;  // thread index inside a warp
-    return tl::is_rowmajor<Layout> ? lane_id / tl::num_cols<Layout>
-                                   : lane_id % tl::num_rows<Layout>;
+
+    // FIXME(haruhi): The switch-case structure is currently inelegant.
+    // Consider refining the code structure using more appropriate methods, such
+    // as partial specialization.
+    switch (tl::layout_type<Layout>) {
+        case tl::Layout::RowMajor:
+            return lane_id / tl::num_cols<Layout>;
+        case tl::Layout::ColMajor:
+            return lane_id % tl::num_rows<Layout>;
+        default:
+            assert(false && "Not implemented yet.");
+    }
 }
 
 // @brief This function returns the lane col of the current thread within a
@@ -88,16 +116,24 @@ DEVICE int lane_row_id() {
 template <typename Layout>
 DEVICE int lane_col_id() {
     int lane_id = threadIdx.x % warpSize;  // thread index inside a warp
-    return tl::is_rowmajor<Layout> ? lane_id % tl::num_cols<Layout>
-                                   : lane_id / tl::num_rows<Layout>;
+
+    // FIXME(haruhi): The switch-case structure is currently inelegant.
+    // Consider refining the code structure using more appropriate methods, such
+    // as partial specialization.
+    switch (tl::layout_type<Layout>) {
+        case tl::Layout::RowMajor:
+            return lane_id % tl::num_cols<Layout>;
+        case tl::Layout::ColMajor:
+            return lane_id / tl::num_rows<Layout>;
+        default:
+            assert(false && "Not implemented yet.");
+    }
 }
 
 // @brief This function returns the offset to the start position of the current
 //        warp in the shared memory according to the warp reuse mode.
 template <const WarpReuse kMode, typename Shared, typename WarpLayout>
 DEVICE int get_warp_offset() {
-    constexpr static bool row_major = Shared::kIsRowMajor;
-
     // Tile shape for a single warp
     constexpr static int warp_shape_row =
         Shared::kRows / tl::num_rows<WarpLayout>;
@@ -105,42 +141,38 @@ DEVICE int get_warp_offset() {
         Shared::kCols / tl::num_cols<WarpLayout>;
 
     constexpr static int warp_rstride =
-        row_major ? Shared::kRowStride * warp_shape_row : warp_shape_row;
+        Shared::type == tl::Layout::RowMajor
+            ? Shared::kRowStride * warp_shape_row
+            : warp_shape_row;
     constexpr static int warp_cstride =
-        row_major ? warp_shape_col : Shared::kColStride * warp_shape_col;
+        Shared::type == tl::Layout::RowMajor
+            ? warp_shape_col
+            : Shared::kColStride * warp_shape_col;
 
-    int offset = 0;
     switch (kMode) {
         case WarpReuse::Cont: {
             // In 'Cont' mode, all warps evenly divide the large data tiles
             // and load the data without repeated loads.
             int warp_row = warp_row_id<WarpLayout>();
             int warp_col = warp_col_id<WarpLayout>();
-            offset = warp_row * warp_rstride + warp_col * warp_cstride;
-            break;
+            return warp_row * warp_rstride + warp_col * warp_cstride;
         }
         case WarpReuse::RowReuseCont: {
             // In the `RowReuseCont` mode, warps in a same row repeatedly load
             // the same data, and each warp loads a continuous chunks of data.
             int warp_row = warp_row_id<WarpLayout>();
-            offset = warp_row * warp_rstride;
-            break;
+            return warp_row * warp_rstride;
         }
         case WarpReuse::ColReuseCont: {
             // In the `ColReuseCont` mode, warps in a same column repeatedly
             // load the same data, and each warp loads a continuous chunks of
             // data.
             int warp_col = warp_col_id<WarpLayout>();
-            offset = warp_col * warp_cstride;
-            break;
+            return warp_col * warp_cstride;
         }
-        default: {
-            // simulate "the not implemented error"
+        default:
             assert(false && "Not implemented yet.");
-            break;
-        }
     }
-    return offset;
 }
 
 // @brief This function returns the number of times a `BaseTile` is executed
@@ -156,9 +188,9 @@ DEVICE static constexpr int row_exec_count() {
 
     int count = 0;
     switch (mode) {
-        /// Warps in the same columns (`warps_per_row` in total) repeatedly load
-        /// the shared memory rows. Therefore, `row_exec` is not divided by
-        /// warps_per_row.
+        // Warps in the same columns (`warps_per_row` in total) repeatedly load
+        // the shared memory rows. Therefore, `row_exec` is not divided by
+        // warps_per_row.
         case WarpReuse::ColReuseCont:
         case WarpReuse::ColReuseCir:
             count = rows / base_tile_row;
@@ -170,8 +202,8 @@ DEVICE static constexpr int row_exec_count() {
 
     // Check to ensure that the count is not zero, which could be caused by an
     // incorrect combination of shared memory tile shape and warp layout.
-    // TODO: This should actually be a static assert, but we're
-    // currently using a runtime assert for implementation issues.
+    // TODO: This should actually be a static assert, but we're currently using
+    // a runtime assert for implementation issues.
     assert(count);
     return count;
 }
@@ -187,9 +219,9 @@ DEVICE static constexpr int col_exec_count() {
 
     int count = 0;
     switch (mode) {
-        /// Warps in the same rows (`warps_per_col` in total) repeatedly load
-        /// the shared memory columns. Therefore, `col_exec` is not divided by
-        /// `warps_per_col`.
+        // Warps in the same rows (`warps_per_col` in total) repeatedly load the
+        // shared memory columns. Therefore, `col_exec` is not divided by
+        // `warps_per_col`.
         case WarpReuse::RowReuseCont:
         case WarpReuse::RowReuseCir:
             count = cols / base_tile_col;
@@ -219,7 +251,7 @@ DEVICE void ldmatrix(const Element* src, Element* dst) {
 
 namespace detail {
 
-template <typename Shared, const bool isRowMajor>
+template <typename Shared, const tl::Layout type>
 struct LoadTileImpl {
     using DType = typename Shared::DType;
 
@@ -229,7 +261,7 @@ struct LoadTileImpl {
 
 /// @brief partial specialization for row-major shared memory tile.
 template <typename Shared>
-struct LoadTileImpl<Shared, true> {
+struct LoadTileImpl<Shared, tl::Layout::RowMajor> {
     using DType = typename Shared::DType;
 
     // strides to iterate over each 16x128-bits `BaseTile`.
@@ -270,7 +302,7 @@ struct LoadTileImpl<Shared, true> {
 
 /// @brief partial specialization for column-major shared memory tile.
 template <typename Shared>
-struct LoadTileImpl<Shared, false> {
+struct LoadTileImpl<Shared, tl::Layout::ColMajor> {
     using DType = typename Shared::DType;
 
     // strides to iterate over each 16x128-bits `BaseTile`.
@@ -354,14 +386,14 @@ struct SharedToRegLoader<Reg_, WarpLayout_, kMode, CopyInst::LoadMat> {
         int col_exec = col_exec_count<DType, Shared::kCols,
                                       tl::num_cols<WarpLayout>, kMode>();
 
-        detail::LoadTileImpl<Shared, Shared::kIsRowMajor> loader;
+        detail::LoadTileImpl<Shared, Shared::type> loader;
         loader(src_ptr, dst.mutable_data(), row_exec, col_exec);
     }
 };
 
 ///@brief A functor that implements threads in a CTA to cooperatively store a
 ///       register tile in shared memory.
-template <typename Reg, typename WarpLayout, RegLayout kRegLayout,
+template <typename Reg, typename WarpLayout, tl::RegLayout kRegLayout,
           CopyInst kCopyInst>
 struct RegToSharedStorer {
     // shared memory tile may be computed from runtime value, thus leave it as a
@@ -372,7 +404,7 @@ struct RegToSharedStorer {
 
 ///@brief partial specialization for wmma 16x16x16, and LDSM32
 template <typename Reg_, typename WarpLayout_>
-struct RegToSharedStorer<Reg_, WarpLayout_, RegLayout::WMMA_m16n16k16,
+struct RegToSharedStorer<Reg_, WarpLayout_, tl::RegLayout::WMMA_m16n16k16,
                          CopyInst::LoadS32> {
     using Reg = Reg_;
     using WarpLayout = WarpLayout_;
@@ -386,7 +418,6 @@ struct RegToSharedStorer<Reg_, WarpLayout_, RegLayout::WMMA_m16n16k16,
             (Reg::kNumel * 32 * tl::get_numel<WarpLayout>) == Shared::kNumel,
             "The number of elements in Reg and Shared must be the same.");
 
-        const bool row_major = Shared::kIsRowMajor;  // get the layout of shared
         const DType* src_ptr = src.data();    // pointer for register tile
         DType* dst_ptr = dst.mutable_data();  // pointer for shared memory tile
 
@@ -412,24 +443,30 @@ struct RegToSharedStorer<Reg_, WarpLayout_, RegLayout::WMMA_m16n16k16,
         // register.
         static constexpr int stride = 2;
         static constexpr int rstride =
-            row_major ? tl::num_rows<ThreadWmma> * Shared::kRowStride
-                      : tl::num_rows<ThreadWmma>;
+            Shared::type == tl::Layout::RowMajor
+                ? tl::num_rows<ThreadWmma> * Shared::kRowStride
+                : tl::num_rows<ThreadWmma>;
         static constexpr int cstride =
-            row_major ? stride * tl::num_cols<ThreadWmma>
-                      : stride * tl::num_cols<ThreadWmma> * Shared::kColStride;
+            Shared::type == tl::Layout::RowMajor
+                ? stride * tl::num_cols<ThreadWmma>
+                : stride * tl::num_cols<ThreadWmma> * Shared::kColStride;
 
         // strides to iterate over each 16x128-bits `Base Tile` in the shared
         // memory
         const int tile_rstride =  // row stride for a `Base Tile`
-            row_major ? BaseTileShape<DType>::row * Shared::kRowStride
-                      : BaseTileShape<DType>::row;
-        const int tile_cstride = row_major ? 16 : 16 * Shared::kColStride;
+            Shared::type == tl::Layout::RowMajor
+                ? BaseTileShape<DType>::row * Shared::kRowStride
+                : BaseTileShape<DType>::row;
+        const int tile_cstride =
+            Shared::type == tl::Layout::RowMajor ? 16 : 16 * Shared::kColStride;
 
         // Given the lane position of the current thread, calculate the strides
         // needed to address the data within the 16x128-bit `BaseTile` for the
         // current thread.
-        const int lane_rstride = row_major ? Shared::kRowStride : stride;
-        const int lane_cstride = row_major ? stride : Shared::kColStride;
+        const int lane_rstride =
+            Shared::type == tl::Layout::RowMajor ? Shared::kRowStride : stride;
+        const int lane_cstride =
+            Shared::type == tl::Layout::RowMajor ? stride : Shared::kColStride;
 
         DType* data;
         int lane_row = lane_row_id<traits::ThreadWmma>();

--- a/include/types/register.hpp
+++ b/include/types/register.hpp
@@ -13,6 +13,10 @@ class RegTile {
     using DType = Element_;
     using Layout = Layout_;
 
+    // FIXME: This member is not properly set in the current implementation.
+    // It exists to ensure that RegTile has a similar interface to SharedTile.
+    static constexpr tl::RegLayout type = tl::RegLayout::Default;
+
     static constexpr int kNumel = tl::get_numel<Layout>;
     static constexpr int kRows = tl::num_rows<Layout>;
     static constexpr int kCols = tl::num_cols<Layout>;

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -22,7 +22,7 @@ class SharedTile {
     static constexpr int kRowStride = tl::row_stride<Layout>;
     static constexpr int kColStride = tl::col_stride<Layout>;
 
-    static constexpr bool kIsRowMajor = tl::is_rowmajor<Layout>;
+    static constexpr tl::Layout type = tl::layout_type<Layout>;
 
     DEVICE SharedTile(DType* data) : data_(data), layout_(Layout{}) {}
 

--- a/include/types/tile_iterator.hpp
+++ b/include/types/tile_iterator.hpp
@@ -57,7 +57,7 @@ class SharedTileIterator {
                                           Tile::kColStride>());
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
 
-        int offset = Tile::kIsRowMajor
+        int offset = Tile::type == tl::Layout::RowMajor
                          ? x * (kStride0 * Tile::kRowStride) + y * kStride1
                          : x * kStride0 + y * (Tile::kColStride * kStride1);
 
@@ -75,7 +75,7 @@ class SharedTileIterator {
                                           Tile::kColStride>());
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
 
-        int offset = Tile::kIsRowMajor
+        int offset = Tile::type == tl::Layout::RowMajor
                          ? x * (kStride0 * Tile::kCols) + y * kStride1
                          : x * kStride0 + y * (Tile::kRows * kStride1);
         NewTile tile(data_ + offset);
@@ -97,8 +97,9 @@ class SharedTileIterator {
         static_assert(Iter::sc0 == 1);
 
         // advance pointer to the correct start position
-        int offset =
-            Tile::kIsRowMajor ? x * (kStride0 * Tile::kCols) : x * kStride0;
+        int offset = Tile::type == tl::Layout::RowMajor
+                         ? x * (kStride0 * Tile::kCols)
+                         : x * kStride0;
 
         Iter iter(data_ + offset);
         return iter;
@@ -118,8 +119,9 @@ class SharedTileIterator {
         static_assert(Iter::sc1 == 1);
 
         // advance pointer to the correct start position
-        int offset =
-            Tile::kIsRowMajor ? y * kStride1 : y * (Tile::kRows * kStride1);
+        int offset = Tile::type == tl::Layout::RowMajor
+                         ? y * kStride1
+                         : y * (Tile::kRows * kStride1);
 
         Iter iter(data_ + offset);
         return iter;

--- a/tests/cpp/cell/test_gemm.cu
+++ b/tests/cpp/cell/test_gemm.cu
@@ -187,7 +187,7 @@ struct TestTraits {
 
     // store RegTileC to shared
     using StoreRegC = RegToSharedStorer<RegC, WarpLayout,
-                                        RegLayout::WMMA_m16n16k16,  //
+                                        tl::RegLayout::WMMA_m16n16k16,  //
                                         CopyInst::LoadS32>;
 };
 

--- a/tests/cpp/cell/test_gemm.cu
+++ b/tests/cpp/cell/test_gemm.cu
@@ -32,23 +32,22 @@ bool check_correctness(const half* hc1, const float* hc2, int row, int col) {
     static const float eps = 5e-2;
 
 #if defined(DEBUG)
-    int print_cut = numel;
     std::stringstream ss;
     ss << std::setprecision(3) << std::endl
        << "ours:" << std::endl
        << 0 << ":\t";
-    for (int i = 0; i < print_cut; ++i) {
+    for (int i = 0; i < numel; ++i) {
         ss << hc2[i] << ", ";
-        if (i & (i + 1) % 16 == 0) {
-            ss << std::endl << (i + 1) / 16 << ":\t";
+        if (i & (i + 1) % 32 == 0) {
+            ss << std::endl << (i + 1) / 32 << ":\t";
         }
     }
 
     ss << std::endl << "cublas:" << std::endl << 0 << ":\t";
-    for (int i = 0; i < print_cut; ++i) {
+    for (int i = 0; i < numel; ++i) {
         ss << __half2float(hc1[i]) << ", ";
-        if (i & (i + 1) % 16 == 0) {
-            ss << std::endl << (i + 1) / 16 << "\t";
+        if (i & (i + 1) % 32 == 0) {
+            ss << std::endl << (i + 1) / 32 << "\t";
         }
     }
     LOG(INFO) << ss.str();
@@ -255,22 +254,12 @@ void run_test() {
 
     // initialize data
     thrust::host_vector<Element> h_a(M * K);
-    for (int i = 0; i < h_a.size(); ++i) {
-#if defined(DEBUG)
-        h_a[i] = static_cast<Element>(i % 2048);
-#else
+    for (int i = 0; i < h_a.size(); ++i)
         h_a[i] = static_cast<Element>(rand_float());
-#endif
-    }
 
     thrust::host_vector<Element> h_b(K * N);
-    for (int i = 0; i < h_b.size(); ++i) {
-#if defined(DEBUG)
-        h_b[i] = static_cast<Element>(i % 2048);
-#else
+    for (int i = 0; i < h_b.size(); ++i)
         h_b[i] = static_cast<Element>(rand_float());
-#endif
-    }
 
     thrust::host_vector<ElementAcc> h_c(M * N);
     thrust::fill(h_c.begin(), h_c.end(), 0.);

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -147,8 +147,9 @@ TEST(TestReg2Shared, operand_C) {
         SharedToRegLoader<Reg, WarpLayout, WarpReuse::Cont, CopyInst::LoadMat>;
     Loader loader;
 
-    using Storer = RegToSharedStorer<Reg, WarpLayout, RegLayout::WMMA_m16n16k16,
-                                     CopyInst::LoadS32>;
+    using Storer =
+        RegToSharedStorer<Reg, WarpLayout, tl::RegLayout::WMMA_m16n16k16,
+                          CopyInst::LoadS32>;
     Storer storer;
 
     dim3 dim_grid(1, 1, 1);

--- a/tests/cpp/cell/test_single_wmma.cu
+++ b/tests/cpp/cell/test_single_wmma.cu
@@ -147,7 +147,7 @@ struct TestTraits {
     using SharedC = SharedTile<ElementAcc, tl::RowMajor<M, N>>;
     using RegC = RegTile<ElementAcc, tl::RowMajor<ms * 2, ns * 4>>;
     using StoreRegC =
-        RegToSharedStorer<RegC, WarpLayout, RegLayout::WMMA_m16n16k16,
+        RegToSharedStorer<RegC, WarpLayout, tl::RegLayout::WMMA_m16n16k16,
                           CopyInst::LoadS32>;
 };
 


### PR DESCRIPTION
resolve https://github.com/TiledTensor/TiledCUDA/issues/55

`ldmatrix` can be executed along two dimensions. In the current implementation for WMMA, the iteration over the k-dimension occurs in the innermost loop of the triple loop structure used in GEMM computations.

The bug arises because the current implementation of `ldmatrix` always iterates over the columns of a matrix first, followed by the rows. When operand `B` is laid out in column-major format, this causes a mismatch with WMMA's input data requirements.
