### PR TITLE
chore: rename `SharedTileIterator` into `TileIterator`

### DIFF
--- a/include/cell/copy/constants.hpp
+++ b/include/cell/copy/constants.hpp
@@ -16,14 +16,14 @@ enum class WarpReuse {
     // TODO(haruhi): It seems that Cir/RowReuseCir/ColReuseCir are not ncessary,
     // thus the reuse mode can be simplified.
     // data are evenly partitioned to be loaded by warps.
-    Cont = 0,          // all warps continuously load data, no reuse
-    Cir = 1,           // all warps circularly load data, no reuse
-    RowReuseCont = 2,  // Row-wise even reuse, warps in the same row
-                       // repeatedly load the same data
-    RowReuseCir = 3,   // Row-wise circular reuse
-    ColReuseCont = 4,  // Column-wise even reuse, warps in the same column
-                       // repeatedly load the same data
-    ColReuseCir = 5    // Column-wise circular reuse
+    kCont = 0,          // all warps continuously load data, no reuse
+    kCir = 1,           // all warps circularly load data, no reuse
+    kRowReuseCont = 2,  // Row-wise even reuse, warps in the same row
+                        // repeatedly load the same data
+    kRowReuseCir = 3,   // Row-wise circular reuse
+    kColReuseCont = 4,  // Column-wise even reuse, warps in the same column
+                        // repeatedly load the same data
+    kColReuseCir = 5    // Column-wise circular reuse
 };
 
 }  // namespace tiledcuda::cell::copy

--- a/include/cell/copy/copy_atom.hpp
+++ b/include/cell/copy/copy_atom.hpp
@@ -78,11 +78,11 @@ struct StoreMmmaBase {
     // and `kCStride` calculate the row and column strides, respectively, when
     // iterating over these 4 segments in shared memory.
     static constexpr int kRstride =
-        Shared::type == tl::Layout::RowMajor
+        Shared::kType == tl::Layout::kRowMajor
             ? tl::num_rows<ThreadLayout> * Shared::kRowStride
             : tl::num_rows<ThreadLayout>;
     static constexpr int kCstride =
-        Shared::type == tl::Layout::RowMajor
+        Shared::kType == tl::Layout::kRowMajor
             ? kElemPerSeg * tl::num_cols<ThreadLayout>
             : kElemPerSeg * tl::num_cols<ThreadLayout> * Shared::kColStride;
 
@@ -104,7 +104,7 @@ struct StoreMmmaBase {
         int src_offset, dst_offset;
         for (int i = 0; i < kSegRows; ++i) {
             for (int j = 0; j < kSegCols; ++j) {
-                src_offset = RegTile::kType == tl::Layout::RowMajor
+                src_offset = RegTile::kType == tl::Layout::kRowMajor
                                  ? i * kElemPerRow + j * kElemPerSeg
                                  : j * kElemPerRow + i * kElemPerSeg;
 

--- a/include/cell/copy/global_to_register.hpp
+++ b/include/cell/copy/global_to_register.hpp
@@ -24,7 +24,7 @@ struct GlobalToRegMatLoader {
 };
 
 template <typename Global_, typename BaseTile_>
-struct GlobalToRegMatLoader<Global_, BaseTile_, tl::Layout::RowMajor> {
+struct GlobalToRegMatLoader<Global_, BaseTile_, tl::Layout::kRowMajor> {
     using Global = Global_;
     using BaseTile = BaseTile_;
     using DType = Global::DType;
@@ -44,7 +44,7 @@ struct GlobalToRegMatLoader<Global_, BaseTile_, tl::Layout::RowMajor> {
 };
 
 template <typename Global_, typename BaseTile_>
-struct GlobalToRegMatLoader<Global_, BaseTile_, tl::Layout::ColMajor> {
+struct GlobalToRegMatLoader<Global_, BaseTile_, tl::Layout::kColMajor> {
     using Global = Global_;
     using BaseTile = BaseTile_;
     using DType = Global::DType;
@@ -79,7 +79,7 @@ struct RegToGlobalMatStorer {
 };
 
 template <typename Global_, typename BaseTile_>
-struct RegToGlobalMatStorer<Global_, BaseTile_, tl::Layout::RowMajor> {
+struct RegToGlobalMatStorer<Global_, BaseTile_, tl::Layout::kRowMajor> {
     using Global = Global_;
     using BaseTile = BaseTile_;
     using DType = Global::DType;
@@ -99,7 +99,7 @@ struct RegToGlobalMatStorer<Global_, BaseTile_, tl::Layout::RowMajor> {
 };
 
 template <typename Global_, typename BaseTile_>
-struct RegToGlobalMatStorer<Global_, BaseTile_, tl::Layout::ColMajor> {
+struct RegToGlobalMatStorer<Global_, BaseTile_, tl::Layout::kColMajor> {
     using Global = Global_;
     using BaseTile = BaseTile_;
     using DType = Global::DType;
@@ -131,7 +131,7 @@ template <typename Global_, typename Reg_, const int kRowExec_,
 struct GlobalToRegLoaderImpl {
     using Global = Global_;
     using Reg = Reg_;
-    using DType = Global::type;
+    using DType = Global::DType;
 
     DEVICE void operator()(const DType* src, Reg& dst);
 };
@@ -139,7 +139,7 @@ struct GlobalToRegLoaderImpl {
 template <typename Global_, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct GlobalToRegLoaderImpl<Global_, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::RowMajor> {
+                             tl::Layout::kRowMajor> {
     using Global = Global_;
     using Reg = Reg_;
     using DType = typename Global::DType;
@@ -157,7 +157,7 @@ struct GlobalToRegLoaderImpl<Global_, Reg_, kRowExec_, kColExec_,
         const DType* data;
 
         using Loader =
-            GlobalToRegMatLoader<Global, BaseTile, tl::Layout::RowMajor>;
+            GlobalToRegMatLoader<Global, BaseTile, tl::Layout::kRowMajor>;
         Loader loader;
 #pragma unroll
         for (int i = 0; i < kRowExec; ++i) {
@@ -177,7 +177,7 @@ struct GlobalToRegLoaderImpl<Global_, Reg_, kRowExec_, kColExec_,
 template <typename Global_, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct GlobalToRegLoaderImpl<Global_, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::ColMajor> {
+                             tl::Layout::kColMajor> {
     using Global = Global_;
     using Reg = Reg_;
     using DType = typename Global::DType;
@@ -195,7 +195,7 @@ struct GlobalToRegLoaderImpl<Global_, Reg_, kRowExec_, kColExec_,
         const DType* data;
 
         using Loader =
-            GlobalToRegMatLoader<Global, BaseTile, tl::Layout::ColMajor>;
+            GlobalToRegMatLoader<Global, BaseTile, tl::Layout::kColMajor>;
         Loader loader;
 
 #pragma unroll
@@ -224,7 +224,7 @@ template <typename Global_, typename Reg_, const int kRowExec_,
 struct RegToGlobalStorerImpl {
     using Global = Global_;
     using Reg = Reg_;
-    using DType = Global::type;
+    using DType = Global::DType;
 
     DEVICE void operator()(const Reg& src, DType* dst);
 };
@@ -232,7 +232,7 @@ struct RegToGlobalStorerImpl {
 template <typename Global_, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::RowMajor> {
+                             tl::Layout::kRowMajor> {
     using Global = Global_;
     using Reg = Reg_;
     using DType = typename Global::DType;
@@ -247,7 +247,7 @@ struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
         DType* data;
 
         using Storer = RegToGlobalMatStorer<Global, typename Reg::DType,
-                                            tl::Layout::RowMajor>;
+                                            tl::Layout::kRowMajor>;
         Storer storer;
 
 #pragma unroll
@@ -267,7 +267,7 @@ struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
 template <typename Global_, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::ColMajor> {
+                             tl::Layout::kColMajor> {
     using Global = Global_;
     using Reg = Reg_;
     using DType = typename Global::DType;
@@ -280,9 +280,8 @@ struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
         int lane_id = threadIdx.x % warpSize;
 
         DType* data;
-
         using Storer = RegToGlobalMatStorer<Global, typename Reg::DType,
-                                            tl::Layout::ColMajor>;
+                                            tl::Layout::kColMajor>;
         Storer storer;
 
 #pragma unroll
@@ -335,7 +334,7 @@ struct GlobalToRegLoader : public Base {
             Base::template col_exec_count<BaseShape, Global::kCols>();
 
         using Loader = GlobalToRegLoaderImpl<Global, Reg, kRowExec, kColExec,
-                                             Global::type>;
+                                             Global::kType>;
         Loader loader;
         loader(src_ptr, dst);
     }
@@ -351,7 +350,7 @@ struct GlobalToRegLoader : public Base {
  * @tparam Base Copy base.
  */
 template <typename Global_, typename Reg_, typename WarpLayout_,
-          typename Base = warp::CopyBase<WarpLayout_, WarpReuse::Cont>>
+          typename Base = warp::CopyBase<WarpLayout_, WarpReuse::kCont>>
 struct RegToGlobalStorer : public Base {
     using Global = Global_;
     using Reg = Reg_;
@@ -375,7 +374,7 @@ struct RegToGlobalStorer : public Base {
             Base::template col_exec_count<BaseShape, Global::kCols>();
 
         using Storer = RegToGlobalStorerImpl<Global, Reg, kRowExec, kColExec,
-                                             Global::type>;
+                                             Global::kType>;
         Storer storer;
         storer(src, dst_ptr);
     }

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -26,7 +26,7 @@ struct SharedToRegLoaderImpl {
 template <typename Shared, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct SharedToRegLoaderImpl<Shared, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::RowMajor, CopyInst::kLoadMat>
+                             tl::Layout::kRowMajor, CopyInst::kLoadMat>
     : public LoadMatBase<typename Shared::DType> {
     using LoadMat = LoadMatBase<typename Shared::DType>;
     using DType = Shared::DType;
@@ -70,7 +70,7 @@ struct SharedToRegLoaderImpl<Shared, Reg_, kRowExec_, kColExec_,
 template <typename Shared, typename Reg_, const int kRowExec_,
           const int kColExec_>
 struct SharedToRegLoaderImpl<Shared, Reg_, kRowExec_, kColExec_,
-                             tl::Layout::ColMajor, CopyInst::kLoadMat>
+                             tl::Layout::kColMajor, CopyInst::kLoadMat>
     : public LoadMatBase<typename Shared::DType> {
     using LoadMat = LoadMatBase<typename Shared::DType>;
     using DType = Shared::DType;
@@ -139,11 +139,11 @@ struct RegToSharedStorerImpl<Shared, Reg_, kRowExec_, kColExec_,
 
     // strides to iterate over each 16x16 `BaseTile` in the shared memory
     static constexpr int kTileRstride =  // row stride for a `BaseTile`
-        Shared::type == tl::Layout::RowMajor
+        Shared::kType == tl::Layout::kRowMajor
             ? BaseShape::kRows * Shared::kRowStride
             : BaseShape::kRows;
     static constexpr int kTileCstride =
-        Shared::type == tl::Layout::RowMajor
+        Shared::kType == tl::Layout::kRowMajor
             ? BaseShape::kCols
             : BaseShape::kCols * Shared::kColStride;
 
@@ -151,10 +151,10 @@ struct RegToSharedStorerImpl<Shared, Reg_, kRowExec_, kColExec_,
     // needed to address the data within the 16x16 `BaseTile` for the current
     // thread. These strides corresponds to the thread layout and specific
     // instruction used.
-    static constexpr int kLaneRstride = Shared::type == tl::Layout::RowMajor
+    static constexpr int kLaneRstride = Shared::kType == tl::Layout::kRowMajor
                                             ? Shared::kRowStride
                                             : Base::kElemPerSeg;
-    static constexpr int kLaneCstride = Shared::type == tl::Layout::RowMajor
+    static constexpr int kLaneCstride = Shared::kType == tl::Layout::kRowMajor
                                             ? Base::kElemPerSeg
                                             : Shared::kColStride;
 
@@ -218,7 +218,7 @@ struct SharedToRegLoader : public Base {
 
         using Loader =
             detail::SharedToRegLoaderImpl<Shared, Reg, kRowExec, kColExec,
-                                          Shared::type, CopyInst::kLoadMat>;
+                                          Shared::kType, CopyInst::kLoadMat>;
         Loader loader;
         loader(src_ptr, dst);
     }
@@ -228,7 +228,7 @@ struct SharedToRegLoader : public Base {
 ///        to revert the data distrubution into an comphrehensive row-major
 ///        matrix.
 template <typename Reg_, typename WarpLayout_,
-          typename Base = warp::CopyBase<WarpLayout_, WarpReuse::Cont>>
+          typename Base = warp::CopyBase<WarpLayout_, WarpReuse::kCont>>
 struct RegToSharedStorer : public Base {
     using Reg = Reg_;
     // elementary data type stored in the register tile.

--- a/include/cuda_utils.hpp
+++ b/include/cuda_utils.hpp
@@ -39,13 +39,13 @@ inline void __cublasCheck(const cublasStatus_t err, const char* file,
 HOST_DEVICE
 const char* layout_type_to_str(tl::Layout type) {
     switch (type) {
-        case tl::Layout::RowMajor:
+        case tl::Layout::kRowMajor:
             return "RowMajor";
-        case tl::Layout::ColMajor:
+        case tl::Layout::kColMajor:
             return "ColMajor";
-        case tl::Layout::SwizzledRowMajor:
+        case tl::Layout::kSwizzledRowMajor:
             return "SwizzledRowMajor";
-        case tl::Layout::SwizzledColMajor:
+        case tl::Layout::kSwizzledColMajor:
             return "SwizzledColMajor";
         default:
             return "UnsupportedLayout";

--- a/include/types/global.hpp
+++ b/include/types/global.hpp
@@ -20,7 +20,7 @@ struct GlobalTile {
     static constexpr int kRowStride = tl::row_stride<Layout>;
     static constexpr int kColStride = tl::col_stride<Layout>;
 
-    static constexpr tl::Layout type = tl::layout_type<Layout>;
+    static constexpr tl::Layout kType = tl::layout_type<Layout>;
 
     DEVICE GlobalTile(DType* data) : data_(data), layout_(Layout{}) {}
 

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -18,10 +18,10 @@ namespace tile_layout {
 using namespace cute;
 
 enum class Layout {
-    RowMajor = 0,  // Tile layout for shared memory.
-    ColMajor = 1,
-    SwizzledRowMajor = 2,
-    SwizzledColMajor = 3,
+    kRowMajor = 0,  // Tile layout for shared memory.
+    kColMajor = 1,
+    kSwizzledRowMajor = 2,
+    kSwizzledColMajor = 3,
 };
 
 // In the row major layout, the contiguous dimension in memory is the
@@ -56,7 +56,7 @@ static constexpr size_t get_numel = int(size(Layout_{}));
 // column stride is 1, whereas in a column-major layout, the row stride is 1.
 template <typename Layout_>
 static constexpr Layout layout_type =
-    col_stride<Layout_> == 1 ? Layout::RowMajor : Layout::ColMajor;
+    col_stride<Layout_> == 1 ? Layout::kRowMajor : Layout::kColMajor;
 
 template <const int Shape1, const int Shape2, const int Stride1,
           const int Stride2>

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -21,7 +21,7 @@ class SharedTile {
     static constexpr int kRowStride = tl::row_stride<Layout>;
     static constexpr int kColStride = tl::col_stride<Layout>;
 
-    static constexpr tl::Layout type = tl::layout_type<Layout>;
+    static constexpr tl::Layout kType = tl::layout_type<Layout>;
 
     DEVICE SharedTile(DType* data) : data_(data), layout_(Layout{}) {}
 

--- a/include/types/tile_iterator.hpp
+++ b/include/types/tile_iterator.hpp
@@ -4,14 +4,13 @@
 #include "types/tile_shape.hpp"
 
 namespace tiledcuda::cell {
-
 namespace tl = tile_layout;
 
 struct Underscore {};                  // dummy type for underscore
 static const __device__ Underscore _;  // for slicing
 
 template <class Tile, class ChunkShape>
-struct SharedTileIterator;
+struct TileIterator;
 
 /// @brief `SharedTileIterator` chunks a shared memory tile into smaller tiles
 ///         and iterates over these smaller sub-tiles.
@@ -19,7 +18,7 @@ struct SharedTileIterator;
 /// @tparam ChunkShape_: The shape of the smaller tiles into which the large
 ///                      tile is partitioned (chunk shape).
 template <class Tile_, class ChunkShape_>
-class SharedTileIterator {
+class TileIterator {
   public:
     using Tile = Tile_;
     using ChunkShape = ChunkShape_;
@@ -35,7 +34,7 @@ class SharedTileIterator {
     static constexpr int sc0 = Tile::kRows / kStride0;
     static constexpr int sc1 = Tile::kCols / kStride1;
 
-    DEVICE SharedTileIterator(typename Tile::DType* data) : data_(data) {}
+    DEVICE TileIterator(typename Tile::DType* data) : data_(data) {}
 
     // Since a Tile is considered to be at most a 2D array, the iterator
     // traverses over these two dimensions. The current rules are:
@@ -93,7 +92,7 @@ class SharedTileIterator {
                                                          Tile::kColStride>());
 
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
-        using Iter = SharedTileIterator<NewTile, ChunkShape>;
+        using Iter = TileIterator<NewTile, ChunkShape>;
         static_assert(Iter::sc0 == 1);
 
         // advance pointer to the correct start position
@@ -115,7 +114,7 @@ class SharedTileIterator {
                                                          Tile::kColStride>());
 
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
-        using Iter = SharedTileIterator<NewTile, ChunkShape>;
+        using Iter = TileIterator<NewTile, ChunkShape>;
         static_assert(Iter::sc1 == 1);
 
         // advance pointer to the correct start position

--- a/include/types/tile_iterator.hpp
+++ b/include/types/tile_iterator.hpp
@@ -56,7 +56,7 @@ class TileIterator {
                                           Tile::kColStride>());
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
 
-        int offset = Tile::type == tl::Layout::RowMajor
+        int offset = Tile::kType == tl::Layout::kRowMajor
                          ? x * (kStride0 * Tile::kRowStride) + y * kStride1
                          : x * kStride0 + y * (Tile::kColStride * kStride1);
 
@@ -74,7 +74,7 @@ class TileIterator {
                                           Tile::kColStride>());
         using NewTile = SharedTile<typename Tile::DType, TileLayout>;
 
-        int offset = Tile::type == tl::Layout::RowMajor
+        int offset = Tile::kType == tl::Layout::kRowMajor
                          ? x * (kStride0 * Tile::kCols) + y * kStride1
                          : x * kStride0 + y * (Tile::kRows * kStride1);
         NewTile tile(data_ + offset);
@@ -96,7 +96,7 @@ class TileIterator {
         static_assert(Iter::sc0 == 1);
 
         // advance pointer to the correct start position
-        int offset = Tile::type == tl::Layout::RowMajor
+        int offset = Tile::kType == tl::Layout::kRowMajor
                          ? x * (kStride0 * Tile::kCols)
                          : x * kStride0;
 
@@ -118,7 +118,7 @@ class TileIterator {
         static_assert(Iter::sc1 == 1);
 
         // advance pointer to the correct start position
-        int offset = Tile::type == tl::Layout::RowMajor
+        int offset = Tile::kType == tl::Layout::kRowMajor
                          ? y * kStride1
                          : y * (Tile::kRows * kStride1);
 

--- a/tests/cpp/cell/test_g2r_copy.cu
+++ b/tests/cpp/cell/test_g2r_copy.cu
@@ -70,7 +70,7 @@ __global__ void store_r2g(Element* dst) {
     int lane_id = threadIdx.x % 32;
 
     switch (kType) {
-        case tl::Layout::RowMajor:
+        case tl::Layout::kRowMajor:
             // row major
             for (int i = 0; i < kHeight; ++i) {
                 int row = i * 16 + lane_id / 4;
@@ -94,7 +94,7 @@ __global__ void store_r2g(Element* dst) {
                 }
             }
             break;
-        case tl::Layout::ColMajor:
+        case tl::Layout::kColMajor:
             // col major
             for (int i = 0; i < kWidth; ++i) {
                 int col = i * 16 + lane_id / 4;
@@ -171,11 +171,11 @@ TEST(TestG2RegCopy, copy_2d_tile_g2r_row_major_0) {
     const int kHeight = 1;
     const int kWidth = 1;
     const int kWarpSize = 1;
-    const copy::WarpReuse kMode = copy::WarpReuse::Cont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kCont;
 
     using GlobalLayout = tl::RowMajor<16 * kHeight, 16 * kWidth>;
 
-    run_load_g2r_test<Element, tl::Layout::RowMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kRowMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileRowMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -188,11 +188,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_row_major_1) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 1;
-    const copy::WarpReuse kMode = copy::WarpReuse::Cont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kCont;
 
     using GlobalLayout = tl::RowMajor<16 * kHeight, 16 * kWidth>;
 
-    run_load_g2r_test<Element, tl::Layout::RowMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kRowMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileRowMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -205,11 +205,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_row_major_2) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 4;
-    const copy::WarpReuse kMode = copy::WarpReuse::RowReuseCont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kRowReuseCont;
 
     using GlobalLayout = tl::RowMajor<16 * kHeight, 16 * kWidth>;
 
-    run_load_g2r_test<Element, tl::Layout::RowMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kRowMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileRowMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -222,11 +222,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_row_major_3) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 4;
-    const copy::WarpReuse kMode = copy::WarpReuse::ColReuseCont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kColReuseCont;
 
     using GlobalLayout = tl::RowMajor<16 * kHeight, 16 * kWidth>;
 
-    run_load_g2r_test<Element, tl::Layout::RowMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kRowMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileRowMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -239,11 +239,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_col_major_0) {
     const int kHeight = 1;
     const int kWidth = 1;
     const int kWarpSize = 1;
-    const copy::WarpReuse kMode = copy::WarpReuse::Cont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kCont;
 
     using GlobalLayout = tl::ColMajor<16 * kWidth, 16 * kHeight>;
 
-    run_load_g2r_test<Element, tl::Layout::ColMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kColMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileColMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -256,11 +256,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_col_major_1) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 1;
-    const copy::WarpReuse kMode = copy::WarpReuse::Cont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kCont;
 
     using GlobalLayout = tl::ColMajor<16 * kWidth, 16 * kHeight>;
 
-    run_load_g2r_test<Element, tl::Layout::ColMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kColMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileColMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -273,11 +273,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_col_major_2) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 4;
-    const copy::WarpReuse kMode = copy::WarpReuse::RowReuseCont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kRowReuseCont;
 
     using GlobalLayout = tl::ColMajor<16 * kWidth, 16 * kHeight>;
 
-    run_load_g2r_test<Element, tl::Layout::ColMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kColMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileColMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -290,11 +290,11 @@ TEST(TestG2RegCopy, load_2d_tile_g2r_col_major_3) {
     const int kHeight = 2;
     const int kWidth = 2;
     const int kWarpSize = 4;
-    const copy::WarpReuse kMode = copy::WarpReuse::ColReuseCont;
+    const copy::WarpReuse kMode = copy::WarpReuse::kColReuseCont;
 
     using GlobalLayout = tl::ColMajor<16 * kWidth, 16 * kHeight>;
 
-    run_load_g2r_test<Element, tl::Layout::ColMajor, WarpLayout, RegLayout,
+    run_load_g2r_test<Element, tl::Layout::kColMajor, WarpLayout, RegLayout,
                       GlobalLayout, BaseTileColMajor<Element>, kMode, kHeight,
                       kWidth, kWarpSize>();
 }
@@ -310,7 +310,7 @@ TEST(TestG2RegCopy, store_2d_tile_r2g_row_major) {
 
     using GlobalLayout = tl::RowMajor<16 * kHeight, 16 * kWidth>;
 
-    run_store_r2g_test<Element, tl::Layout::RowMajor, WarpLayout, RegLayout,
+    run_store_r2g_test<Element, tl::Layout::kRowMajor, WarpLayout, RegLayout,
                        GlobalLayout, BaseTileRowMajor<Element>, kHeight, kWidth,
                        kWarpSize>();
 }
@@ -326,7 +326,7 @@ TEST(TestG2RegCopy, store_2d_tile_r2g_col_major) {
 
     using GlobalLayout = tl::ColMajor<16 * kWidth, 16 * kHeight>;
 
-    run_store_r2g_test<Element, tl::Layout::ColMajor, WarpLayout, RegLayout,
+    run_store_r2g_test<Element, tl::Layout::kColMajor, WarpLayout, RegLayout,
                        GlobalLayout, BaseTileColMajor<Element>, kHeight, kWidth,
                        kWarpSize>();
 }

--- a/tests/cpp/cell/test_gemm.cu
+++ b/tests/cpp/cell/test_gemm.cu
@@ -145,7 +145,7 @@ struct TestTraits {
 
     // load RegTileA from shared
     using LoadRegA =
-        SharedToRegLoader<RegA, WarpLayout, WarpReuse::RowReuseCont>;
+        SharedToRegLoader<RegA, WarpLayout, WarpReuse::kRowReuseCont>;
 
     // register tile for operand B, calculate register usage for operand B
     static constexpr int kBKs = kChunkK / BaseShape::kTileSize;
@@ -155,7 +155,7 @@ struct TestTraits {
 
     // load RegTileB from shared
     using LoadRegB =
-        SharedToRegLoader<RegB, WarpLayout, WarpReuse::ColReuseCont>;
+        SharedToRegLoader<RegB, WarpLayout, WarpReuse::kColReuseCont>;
 
     // shared tile for output C
     using SharedC = SharedTile<ElementAcc, tl::RowMajor<kM, kN>>;

--- a/tests/cpp/cell/test_gemm.cu
+++ b/tests/cpp/cell/test_gemm.cu
@@ -128,11 +128,11 @@ struct TestTraits {
     /// === 3. configurate tile transfer between shared and register loader ===
     // shared tile for operand A
     using SharedA = SharedTile<Element, tl::RowMajor<kM, kK>>;
-    using TileIteratorA = SharedTileIterator<SharedA, TileShape<kM, kChunkK>>;
+    using TileIteratorA = TileIterator<SharedA, TileShape<kM, kChunkK>>;
 
     // shared tile for operand B
     using SharedB = SharedTile<Element, tl::ColMajor<kK, kN>>;
-    using TileIteratorB = SharedTileIterator<SharedB, TileShape<kChunkK, kN>>;
+    using TileIteratorB = TileIterator<SharedB, TileShape<kChunkK, kN>>;
 
     static_assert(TileIteratorA::sc1 == TileIteratorB::sc0,
                   "mismatched K dimension!");

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -99,7 +99,7 @@ TEST(TestShared2Reg, operand_A) {  // load mode for loading operand A in gemm
 
     // In the `RowReuseCont` mode, warps in the same row repeatedly access the
     // same data.
-    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::RowReuseCont>;
+    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::kRowReuseCont>;
     Copy copy;
 
     dim3 dim_grid(1, 1, 1);
@@ -127,7 +127,7 @@ TEST(TestShared2Reg, operand_B) {  // load mode for loading operand B in gemm
     using Reg = RegTile<BaseTileColMajor<Element>, tl::ColMajor<2, 2>>;
     // In the `ColReuseCont` mode, warps in the same column repeatedly access
     // the same data.
-    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::ColReuseCont>;
+    using Copy = SharedToRegLoader<Reg, WarpLayout, WarpReuse::kColReuseCont>;
     Copy copy;
 
     dim3 dim_grid(1, 1, 1);
@@ -148,7 +148,7 @@ TEST(TestReg2Shared, operand_C) {
     using Shared = SharedTile<Element, tl::RowMajor<16, 16>>;
     using Reg = RegTile<BaseTileRowMajor<Element>, tl::RowMajor<1, 1>>;
 
-    using Loader = SharedToRegLoader<Reg, WarpLayout, WarpReuse::Cont>;
+    using Loader = SharedToRegLoader<Reg, WarpLayout, WarpReuse::kCont>;
     Loader loader;
 
     using Storer = RegToSharedStorer<Reg, WarpLayout>;

--- a/tests/cpp/cell/test_single_wmma.cu
+++ b/tests/cpp/cell/test_single_wmma.cu
@@ -132,14 +132,14 @@ struct TestTraits {
 
     using RegA = RegTile<BaseTileRowMajor<Element>, tl::RowMajor<kMs, kKs>>;
     using LoadRegA =
-        SharedToRegLoader<RegA, WarpLayout, WarpReuse::RowReuseCont>;
+        SharedToRegLoader<RegA, WarpLayout, WarpReuse::kRowReuseCont>;
 
     using SharedB = SharedTile<Element, tl::ColMajor<kK, kN>>;
 
     using RegB = RegTile<BaseTileColMajor<Element>, tl::ColMajor<kKs, kNs>>;
     using TileIteratorB = TileIterator<SharedB, TileShape<kK, kN>>;
     using LoadRegB =
-        SharedToRegLoader<RegB, WarpLayout, WarpReuse::ColReuseCont>;
+        SharedToRegLoader<RegB, WarpLayout, WarpReuse::kColReuseCont>;
 
     static_assert(TileIteratorA::sc1 == TileIteratorB::sc0,
                   "dimension mismatch!");

--- a/tests/cpp/cell/test_single_wmma.cu
+++ b/tests/cpp/cell/test_single_wmma.cu
@@ -128,7 +128,7 @@ struct TestTraits {
     static constexpr int kKs = kK / BaseShape::kTileSize;
 
     using SharedA = SharedTile<Element, tl::RowMajor<kM, kK>>;
-    using TileIteratorA = SharedTileIterator<SharedA, TileShape<kM, kK>>;
+    using TileIteratorA = TileIterator<SharedA, TileShape<kM, kK>>;
 
     using RegA = RegTile<BaseTileRowMajor<Element>, tl::RowMajor<kMs, kKs>>;
     using LoadRegA =
@@ -137,7 +137,7 @@ struct TestTraits {
     using SharedB = SharedTile<Element, tl::ColMajor<kK, kN>>;
 
     using RegB = RegTile<BaseTileColMajor<Element>, tl::ColMajor<kKs, kNs>>;
-    using TileIteratorB = SharedTileIterator<SharedB, TileShape<kK, kN>>;
+    using TileIteratorB = TileIterator<SharedB, TileShape<kK, kN>>;
     using LoadRegB =
         SharedToRegLoader<RegB, WarpLayout, WarpReuse::ColReuseCont>;
 

--- a/tests/cpp/cell/test_tile_iterator.cu
+++ b/tests/cpp/cell/test_tile_iterator.cu
@@ -82,7 +82,7 @@ TEST(TestTile, test_row_major) {
     const int cols = 12;
 
     using Tile = SharedTile<Element, tl::RowMajor<rows, cols>>;
-    using Iterator = SharedTileIterator<Tile, TileShape<2, 4>>;
+    using Iterator = TileIterator<Tile, TileShape<2, 4>>;
 
     LOG(INFO) << std::endl << "Test Row-major" << std::endl;
 
@@ -100,7 +100,7 @@ TEST(TestTile, test_col_major) {
     const int cols = 12;
 
     using Tile = SharedTile<Element, tl::ColMajor<rows, cols>>;
-    using Iterator = SharedTileIterator<Tile, TileShape<2, 4>>;
+    using Iterator = TileIterator<Tile, TileShape<2, 4>>;
 
     LOG(INFO) << std::endl << "Test Column-major" << std::endl;
 


### PR DESCRIPTION
1. rename `SharedTileIterator` into `TileIterator`; resolve https://github.com/TiledTensor/TiledCUDA/issues/85
1. fix the naming styling of the constants; 