### PR TITLE
fix(examples): Enhance the GEMM example to process large input matrices using `TileIterator`.

### DIFF
--- a/examples/cpp/gemm/CMakeLists.txt
+++ b/examples/cpp/gemm/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(gemm_example LANGUAGES C CXX CUDA)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
-                      "${PROJECT_SOURCE_DIR}/../../scripts/cmake")
+                      "${PROJECT_SOURCE_DIR}/../../../scripts/cmake")
 
 include(generic)
-set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/../../3rd-party")
+
+set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/../../../3rd-party")
 include_directories(${THIRD_PARTY_DIR}/cutlass/include)
-include_directories("${PROJECT_SOURCE_DIR}/../../include")
+include_directories("${PROJECT_SOURCE_DIR}/../../../include")
 
 add_executable(gemm gemm.cu)

--- a/examples/cpp/gemm/util.hpp
+++ b/examples/cpp/gemm/util.hpp
@@ -52,9 +52,9 @@ bool check_results(const float* values1, const float* values2, int numel) {
 template <typename InType, typename AccType, typename GemmShape>
 struct GemmTraits {
     using BaseShape = traits::BaseTileShape<InType>;
-    static constexpr int kChunkK = 16;
+    static constexpr int kChunkK = 32;
 
-    using WarpLayout = tl::RowMajor<1, 1>;
+    using WarpLayout = tl::RowMajor<2, 2>;
     static constexpr int kThreads = tl::get_numel<WarpLayout> * 32;
     static constexpr int kWarpPerRow = tl::num_rows<WarpLayout>;
     static constexpr int kWarpPerCol = tl::num_cols<WarpLayout>;
@@ -71,7 +71,7 @@ struct GemmTraits {
     static constexpr int kAKs = kChunkK / BaseShape::kTileSize;
     using RegA = RegTile<BaseTileRowMajor<InType>, tl::RowMajor<kAMs, kAKs>>;
 
-    using ALoader = copy::GlobalToRegLoader<GlobalA, RegA, WarpLayout,
+    using ALoader = copy::GlobalToRegLoader<RegA, WarpLayout,
                                             copy::WarpReuse::kRowReuseCont>;
 
     // operand B
@@ -82,7 +82,7 @@ struct GemmTraits {
     static constexpr int kBNs = kN / kWarpPerCol / BaseShape::kTileSize;
     using RegB = RegTile<BaseTileColMajor<InType>, tl::ColMajor<kBKs, kBNs>>;
 
-    using BLoader = copy::GlobalToRegLoader<GlobalB, RegB, WarpLayout,
+    using BLoader = copy::GlobalToRegLoader<RegB, WarpLayout,
                                             copy::WarpReuse::kColReuseCont>;
 
     // output C

--- a/include/cell/copy/global_to_register.hpp
+++ b/include/cell/copy/global_to_register.hpp
@@ -300,25 +300,23 @@ struct RegToGlobalStorerImpl<Global_, Reg_, kRowExec_, kColExec_,
 
 /**
  * @brief Load a data tile from Global memory to Register based on the warp
- * reuse mode.
- * @tparam Global_ Global memory tile type.
+ *        reuse mode.
  * @tparam Reg_ Register tile type.
  * @tparam WarpLayout_ Warp layout type.
  * @tparam kMode_ Warp reuse mode.
  * @tparam Base Copy base.
  */
-template <typename Global_, typename Reg_, typename WarpLayout_,
-          const WarpReuse kMode_,
+template <typename Reg_, typename WarpLayout_, const WarpReuse kMode_,
           typename Base = warp::CopyBase<WarpLayout_, kMode_>>
 struct GlobalToRegLoader : public Base {
-    using Global = Global_;
     using Reg = Reg_;
-    using DType = typename Global::DType;
+    using DType = typename Reg::DType::DType;
     using BaseShape = BaseTileShape<DType>;
 
     using WarpLayout = WarpLayout_;
     static constexpr WarpReuse kMode = kMode_;
 
+    template <typename Global>
     DEVICE void operator()(const Global& src, Reg& dst) {
         const DType* src_ptr = src.data();
 
@@ -342,7 +340,7 @@ struct GlobalToRegLoader : public Base {
 
 /**
  * @brief Store a data tile from Register to Global memory based on the warp
- * reuse mode.
+ *        reuse mode.
  * @tparam Global_ Global memory tile type.
  * @tparam Reg_ Register tile type.
  * @tparam WarpLayout_ Warp layout type.

--- a/include/types/tile_iterator.hpp
+++ b/include/types/tile_iterator.hpp
@@ -13,9 +13,9 @@ struct TileIteratorPrettyPrinter {
     template <typename TileIterator>
     static HOST void print(std::ostream& out, const TileIterator& itr) {
         out << "numel = " << TileIterator::Tile::kNumel << ", ChunkShape["
-            << TileIterator::Tile::kRows << ", " << TileIterator::Tile::kCols
-            << "], sc0 = " << TileIterator::sc0
-            << ", sc1 = " << TileIterator::sc1;
+            << dim_size<0, typename TileIterator::ChunkShape> << ", "
+            << dim_size<1, typename TileIterator::ChunkShape> << "], sc0 = "
+            << TileIterator::sc0 << ", sc1 = " << TileIterator::sc1;
     }
 };
 }  // namespace detail

--- a/tests/cpp/cell/test_g2r_copy.cu
+++ b/tests/cpp/cell/test_g2r_copy.cu
@@ -20,7 +20,7 @@ __global__ void load_g2r(Element* src) {
     SrcTile src_tile(src);
     DstTile dst_tile;
 
-    copy::GlobalToRegLoader<SrcTile, DstTile, WarpLayout, kMode> loader;
+    copy::GlobalToRegLoader<DstTile, WarpLayout, kMode> loader;
     loader(src_tile, dst_tile);
     __syncthreads();
 


### PR DESCRIPTION
* Fix compatibility issue between global-to-register loader and TileIterator's returned type.
* Enhance the GEMM example to process large input matrices using TileIterator.