### PR TITLE
feat(cell): Hide CuTe's layout inside macro kernel's implementations.

### DIFF
--- a/include/cell/traits/b2b_gemm.hpp
+++ b/include/cell/traits/b2b_gemm.hpp
@@ -66,12 +66,15 @@ struct DynBack2BackGemmTraits : public Base {
     using CopyInstG2S = Copy_Atom<DefaultCopy, Element>;
 #endif
     using TiledCopyG2S = decltype(make_tiled_copy(
-        CopyInstG2S{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        CopyInstG2S{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
 
     using TiledCopyS2G = decltype(make_tiled_copy(
         Copy_Atom<DefaultCopy, Element>{},
-        tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
     using SmemLayoutD =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTP>>{}));

--- a/include/cell/traits/bmm.hpp
+++ b/include/cell/traits/bmm.hpp
@@ -43,8 +43,11 @@ struct DynBatchedGemmTraits : public Base {
     static_assert(kThreads == kWarpPerRow * kWarpPerCol * 32);
 
     static constexpr int kNumPerAccess = Base::kNumPerAccess;
-    using SmemLayoutAtom = decltype(composition(
-        Swizzle<2, 3, 3>{}, tl::RowMajor<8, 4 * kNumPerAccess>{}));
+    using SmemLayoutAtom =
+        decltype(composition(Swizzle<2, 3, 3>{},
+
+                             Layout<Shape<_8, Int<4 * kNumPerAccess>>,
+                                    Stride<Int<4 * kNumPerAccess>, _1>>{}));
 
     static constexpr int kThreadsPerCol = CeilDiv<kTK, Base::kNumPerAccess>;
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
@@ -55,7 +58,9 @@ struct DynBatchedGemmTraits : public Base {
     using CopyInstG2S = Copy_Atom<DefaultCopy, Element>;
 #endif
     using TiledCopyG2S = decltype(make_tiled_copy(
-        CopyInstG2S{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        CopyInstG2S{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
 
     using SmemLayoutA =
@@ -65,7 +70,8 @@ struct DynBatchedGemmTraits : public Base {
 
     using TiledCopyS2G = decltype(make_tiled_copy(
         Copy_Atom<DefaultCopy, Element>{},
-        tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));

--- a/include/cell/traits/copy.hpp
+++ b/include/cell/traits/copy.hpp
@@ -22,14 +22,18 @@ struct G2S2DCopyTraits : public Base {
     static constexpr int kShmRows = kShmRows_;
     static constexpr int kShmCols = kShmCols_;
 
-    using SrcLayout = tl::RowMajor<kRows, kCols, kCols>;
-    using DstLayout = tl::RowMajor<kShmRows, kShmCols, kShmCols>;
+    using SrcLayout =
+        cute::Layout<Shape<Int<kRows>, Int<kCols>>, Stride<Int<kCols>, _1>>;
+    using DstLayout = cute::Layout<Shape<Int<kShmRows>, Int<kShmCols>>,
+                                   Stride<Int<kShmCols>, _1>>;
 
     // threads in a thread block are laid out as a 2D tile
     // that has a shape of kThreadsRows x kThreadsCols.
     static constexpr int kThreadsCols = kShmCols / Base::kNumPerAccess;
     static constexpr int kThreadsRows = kThreads / kThreadsCols;
-    using ThreadLayout = tl::RowMajor<kThreadsRows, kThreadsCols, kThreadsCols>;
+    using ThreadLayout =
+        cute::Layout<Shape<Int<kThreadsRows>, Int<kThreadsCols>>,
+                     Stride<Int<kThreadsCols>, _1>>;
 
     using ValueLayout = Layout<Shape<_1, Int<Base::kNumPerAccess>>>;
 
@@ -61,16 +65,21 @@ struct S2G2DCopyTraits : public Base {
     static constexpr int kShmRows = kShmRows_;
     static constexpr int kShmCols = kShmCols_;
 
-    using SrcLayout = tl::RowMajor<kShmRows, kShmCols, kShmCols>;
+    // using SrcLayout = tl::RowMajor<kShmRows, kShmCols, kShmCols>;
+    // using DstLayout = tl::RowMajor<kRows, kCols, kCols>;
 
-    using DstLayout = tl::RowMajor<kRows, kCols, kCols>;
+    using ScrLayout = cute::Layout<Shape<Int<kShmRows>, Int<kShmCols>>,
+                                   Stride<Int<kShmCols>, _1>>;
+    using DstLayout =
+        cute::Layout<Shape<Int<kRows>, Int<kCols>>, Stride<Int<kCols>, _1>>;
 
     // threads in a thread block are laid out as a 2D tile
     // that has a shape of kThreadsRows x kThreadsCols.
     static constexpr int kThreadsCols = kShmCols / Base::kNumPerAccess;
     static constexpr int kThreadsRows = kThreads / kThreadsCols;
-    using ThreadLayout = tl::RowMajor<kThreadsRows, kThreadsCols, kThreadsCols>;
-
+    using ThreadLayout =
+        cute::Layout<Shape<Int<kThreadsRows>, Int<kThreadsCols>>,
+                     Stride<Int<kThreadsCols>, _1>>;
     using ValueLayout = Layout<Shape<_1, Int<Base::kNumPerAccess>>>;
 
     // transfer data from global memory to shared memory has cp.async,

--- a/include/cell/traits/copy.hpp
+++ b/include/cell/traits/copy.hpp
@@ -65,10 +65,7 @@ struct S2G2DCopyTraits : public Base {
     static constexpr int kShmRows = kShmRows_;
     static constexpr int kShmCols = kShmCols_;
 
-    // using SrcLayout = tl::RowMajor<kShmRows, kShmCols, kShmCols>;
-    // using DstLayout = tl::RowMajor<kRows, kCols, kCols>;
-
-    using ScrLayout = cute::Layout<Shape<Int<kShmRows>, Int<kShmCols>>,
+    using SrcLayout = cute::Layout<Shape<Int<kShmRows>, Int<kShmCols>>,
                                    Stride<Int<kShmCols>, _1>>;
     using DstLayout =
         cute::Layout<Shape<Int<kRows>, Int<kCols>>, Stride<Int<kCols>, _1>>;

--- a/include/cell/traits/gemm.hpp
+++ b/include/cell/traits/gemm.hpp
@@ -45,7 +45,9 @@ struct DynGemmTraits : public Base {
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
 
     using SmemLayoutAtom = decltype(composition(
-        Swizzle<2, 3, 3>{}, tl::RowMajor<8, 4 * kNumPerAccess>{}));
+        Swizzle<2, 3, 3>{}, Layout<Shape<_8, Int<4 * kNumPerAccess>>,
+                                   Stride<Int<4 * kNumPerAccess>, _1>>{}));
+
     using SmemLayoutA =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
     using SmemLayoutB =
@@ -57,8 +59,11 @@ struct DynGemmTraits : public Base {
 #else
     using CopyInstG2S = Copy_Atom<DefaultCopy, Element>;
 #endif
+
     using TiledCopyG2S = decltype(make_tiled_copy(
-        CopyInstG2S{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        CopyInstG2S{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
 
     // copy from shared memory to global memory dose not have cp.async support,
@@ -66,7 +71,8 @@ struct DynGemmTraits : public Base {
     // `CopyAtom`.
     using TiledCopyS2G = decltype(make_tiled_copy(
         Copy_Atom<DefaultCopy, Element>{},
-        tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
     using SmemLayoutC =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));

--- a/include/cell/traits/lstm.hpp
+++ b/include/cell/traits/lstm.hpp
@@ -46,7 +46,8 @@ struct DynLstmGateTraits : public Base {
     static constexpr int kThreadsPerRow = CeilDiv<kThreads, kThreadsPerCol>;
 
     using SmemLayoutAtom = decltype(composition(
-        Swizzle<2, 3, 3>{}, tl::RowMajor<8, 4 * kNumPerAccess>{}));
+        Swizzle<2, 3, 3>{}, Layout<Shape<_8, Int<4 * kNumPerAccess>>,
+                                   Stride<Int<4 * kNumPerAccess>, _1>>{}));
 
     using SmemLayoutA =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTK>>{}));
@@ -63,13 +64,17 @@ struct DynLstmGateTraits : public Base {
 #else
     using CopyInstG2S = Copy_Atom<DefaultCopy, Element>;
 #endif
+
     using TiledCopyG2S = decltype(make_tiled_copy(
-        CopyInstG2S{}, tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        CopyInstG2S{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
 
     using TiledCopyS2G = decltype(make_tiled_copy(
         Copy_Atom<DefaultCopy, Element>{},
-        tl::RowMajor<kThreadsPerRow, kThreadsPerCol>{},
+        Layout<Shape<Int<kThreadsPerRow>, Int<kThreadsPerCol>>,
+               Stride<Int<kThreadsPerCol>, _1>>{},
         Layout<Shape<_1, Int<Base::kNumPerAccess>>>{}));
     using SmemLayoutE =
         decltype(tile_to_shape(SmemLayoutAtom{}, Shape<Int<kTM>, Int<kTN>>{}));

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -63,7 +63,7 @@ using ColMajor = MatrixLayout<kRow, kCol, 1, kStride>;
 //         tile should have a shape that is a multiple of 2^B x 2^S x 2^M.
 template <typename Layout_, const int kB, const int kM, const int kS>
 struct Swizzled {
-    // static_assert(Layout_::kNumel % (2 ^ kB * 2 ^ kM * 2 ^ kS) == 0);
+    static_assert(Layout_::kNumel % (1 << kB * 1 << kM * 1 << kS) == 0);
 
     static constexpr int kRows = Layout_::kRows;
     static constexpr int kCols = Layout_::kCols;

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -24,32 +24,92 @@ enum class Layout {
     kSwizzledColMajor = 3
 };
 
+template <const int kRows_, const int kCols_, const int kRowStride_,
+          const int kColStride_>
+struct MatrixLayout {
+    static constexpr int kRows = kRows_;
+    static constexpr int kCols = kCols_;
+
+    static constexpr int kRowStride = kRowStride_;
+    static constexpr int kColStride = kColStride_;
+
+    static constexpr int kNumel = kRows * kCols;
+
+    DEVICE int operator()(int i, int j) const {
+        return i * kRowStride + j * kColStride;
+    }
+};
+
 // In the row major layout, the contiguous dimension in memory is the
 // last dimension.
 template <const int kRow, const int kCol, const int kStride = kCol>
-using RowMajor =
-    cute::Layout<Shape<Int<kRow>, Int<kCol>>, Stride<Int<kStride>, _1>>;
+using RowMajor = MatrixLayout<kRow, kCol, kStride, 1>;
 
 // In the column major layout, the contiguous dimension in memory is the
 // first dimension.
 template <const int kRow, const int kCol, const int kStride = kRow>
-using ColMajor =
-    cute::Layout<Shape<Int<kRow>, Int<kCol>>, Stride<_1, Int<kStride>>>;
+using ColMajor = MatrixLayout<kRow, kCol, 1, kStride>;
 
-template <typename Layout_>
-static constexpr size_t num_rows = cute::size<0>(Layout_{});
+// @brief: leverage CuTe's swizzle functions, swizzle(B, M, S), permute elements
+//         in a 2D coordinate space. This 2D coordinate space has 2^B rows and
+//         2^S columns, and each coordinate position has 2^M elements.
+//         Therefore, to apply a swizzle function to a 2D data tile, the data
+//         tile should have a shape that is a multiple of 2^B x 2^S x 2^M.
+template <typename Layout_, const int kB, const int kM, const int kS>
+struct Swizzled {
+    // static_assert(Layout_::kNumel % (2 ^ kB * 2 ^ kM * 2 ^ kS) == 0);
 
-template <typename Layout_>
-static constexpr size_t num_cols = cute::size<1>(Layout_{});
+    static constexpr int kRows = Layout_::kRows;
+    static constexpr int kCols = Layout_::kCols;
 
-template <typename Layout_>
-static constexpr size_t row_stride = cute::size<0>(Layout_{}.layout().stride());
+    static constexpr int kRowStride = Layout_::kRowStride;
+    static constexpr int kColStride = Layout_::kColStride;
 
-template <typename Layout_>
-static constexpr size_t col_stride = cute::size<1>(Layout_{}.layout().stride());
+    static constexpr int kNumel = Layout_::kNumel;
 
-template <typename Layout_>
-static constexpr size_t get_numel = int(size(Layout_{}));
+    using LayoutAtom =
+        decltype(composition(cute::Swizzle<kB, kS, kM>{},
+                             cute::Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
+    using SwizzledLayout = decltype(tile_to_shape(
+        LayoutAtom{}, cute::Shape<Int<Layout_::kRows>, Int<Layout_::kCols>>{}));
+
+    DEVICE size_t operator()(int i, int j) const { return layout_(i, j); }
+
+  private:
+    SwizzledLayout layout_;
+};
+
+template <typename Layout>
+static constexpr size_t num_rows = Layout::kRows;
+
+template <typename Layout>
+static constexpr size_t num_cols = Layout::kCols;
+
+template <typename Layout>
+static constexpr size_t row_stride = Layout::kRowStride;
+
+template <typename Layout>
+static constexpr size_t col_stride = Layout::kColStride;
+
+template <typename Layout>
+static constexpr size_t get_numel = Layout::kNumel;
+
+// template <typename Layout_>
+// static constexpr size_t num_rows = cute::size<0>(Layout_{});
+
+// template <typename Layout_>
+// static constexpr size_t num_cols = cute::size<1>(Layout_{});
+
+// template <typename Layout_>
+// static constexpr size_t row_stride =
+// cute::size<0>(Layout_{}.layout().stride());
+
+// template <typename Layout_>
+// static constexpr size_t col_stride =
+// cute::size<1>(Layout_{}.layout().stride());
+
+// template <typename Layout_>
+// static constexpr size_t get_numel = size_t(size(Layout_{}));
 
 // We wrap CuTe's `Layout`, which consists of `Shape` and `Stride`, into an
 // intelligent row-major or column-major layout. In a row-major layout, the
@@ -63,8 +123,9 @@ static constexpr Layout layout_type =
 template <const int kShape1, const int kShape2, const int kStride1,
           const int kStride2>
 HOST_DEVICE auto make_tile_layout() {
-    using Layout = cute::Layout<Shape<Int<kShape1>, Int<kShape2>>,
-                                Stride<Int<kStride1>, Int<kStride2>>>;
+    using Layout = MatrixLayout<kShape1, kShape2, kStride1, kStride2>;
+    // using Layout = cute::Layout<Shape<Int<kShape1>, Int<kShape2>>,
+    //                             Stride<Int<kStride1>, Int<kStride2>>>;
     return Layout{};
 }
 
@@ -79,23 +140,6 @@ HOST_DEVICE auto make_col_major_layout(const int row, const int col,
     return cute::make_layout(make_shape(row, col),
                              make_stride(Int<1>{}, stride));
 }
-
-// @brief: leverage CuTe's swizzle functions, swizzle(B, M, S), permute elements
-//         in a 2D coordinate space. This 2D coordinate space has 2^B rows and
-//         2^S columns, and each coordinate position has 2^M elements.
-//         Therefore, to apply a swizzle function to a 2D data tile, the data
-//         tile should have a shape that is a multiple of 2^B x 2^S x 2^M.
-template <typename Layout_, const int kB, const int kM, const int kS>
-struct Swizzled {
-    static_assert(int(cute::size(Layout_{})) % 2 ^ kB * 2 ^ kM * 2 ^ kS == 0);
-
-    using LayoutAtom =
-        decltype(composition(cute::Swizzle<kB, kS, kM>{},
-                             cute::Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
-    using Layout = decltype(tile_to_shape(
-        LayoutAtom{}, cute::Shape<Int<cute::size<0>(Layout_{})>,
-                                  Int<cute::size<1>(Layout_{})>>{}));
-};
 
 }  // namespace tile_layout
 }  // namespace tiledcuda::cell

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@ if(WITH_TESTING)
     cuda_test(${TEST_NAME} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${FILE_PATH}")
   endforeach()
 
-  # cuda_test(test_gemm SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
-  # "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS ${CUDA_CUBLAS_LIBRARIES})
-
+  cuda_test(test_gemm SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
+            "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS
+            ${CUDA_CUBLAS_LIBRARIES})
 endif()

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -17,8 +17,7 @@ if(WITH_TESTING)
     cuda_test(${TEST_NAME} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${FILE_PATH}")
   endforeach()
 
-  cuda_test(test_gemm SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
-            "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS
-            ${CUDA_CUBLAS_LIBRARIES})
+  # cuda_test(test_gemm SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
+  # "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS ${CUDA_CUBLAS_LIBRARIES})
 
 endif()

--- a/tests/cpp/cell/test_g2s_copy_2.cu
+++ b/tests/cpp/cell/test_g2s_copy_2.cu
@@ -29,112 +29,100 @@ __global__ void copy_g2s(const Element* src_ptr, Element* dst_ptr) {
     storer(inter, dst);
 }
 
-// TEST(GlobalToSharedCopy, test_non_swizzled_layout) {
-//     // In the internal implementation of the copy kernel, threads in a warp
-//     are
-//     // arranged in an 8x4 fashion. Consequently, threads in a CTA form an
-//     [32,
-//     // 8] layout (derived from [4x8, 2x4]).
-//     // Given that threads in the same row access the same row in shared
-//     memory.
-//     // Each thread accesses 128 bits of data, which corresponds to 8 elements
-//     of
-//     // half-precision data. Therefore, the shared memory must have a shape
-//     that
-//     // is a multiple of [32, 64].
-//     static constexpr int kRows = 128;
-//     static constexpr int kCols = 64;
+TEST(GlobalToSharedCopy, test_non_swizzled_layout) {
+    // In the internal implementation of the copy kernel, threads in a warp are
+    // arranged in an 8x4 fashion. Consequently, threads in a CTA form an [32,
+    // 8] layout (derived from [4x8, 2x4]).
+    // Given that threads in the same row access the same row in shared memory.
+    // Each thread accesses 128 bits of data, which corresponds to 8 elements of
+    // half-precision data. Therefore, the shared memory must have a shape that
+    // is a multiple of [32, 64].
 
-//     using WarpLayout = tl::RowMajor<4, 2>;
-//     static const int kThreads = tl::get_numel<WarpLayout> * 32;
+    static constexpr int kRows = 128;
+    static constexpr int kCols = 64;
 
-//     using Element = __half;
-//     // initalize the input matrix
-//     int numel = kRows * kCols;
-//     thrust::host_vector<Element> h_A(numel);
-//     for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
+    using WarpLayout = tl::RowMajor<4, 2>;
+    static const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-//     thrust::device_vector<Element> d_B(numel);
-//     thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
-//     thrust::device_vector<Element> d_A = h_A;
+    using Element = __half;
+    // initalize the input matrix
+    int numel = kRows * kCols;
+    thrust::host_vector<Element> h_A(numel);
+    for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
 
-//     using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
-//     using DstTile = SharedTile<Element, tl::RowMajor<kRows, kCols>>;
-//     using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
-//     using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
+    thrust::device_vector<Element> d_B(numel);
+    thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
+    thrust::device_vector<Element> d_A = h_A;
 
-//     dim3 dim_grid(1, 1);
-//     dim3 dim_block(kThreads);
+    using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
+    using DstTile = SharedTile<Element, tl::RowMajor<kRows, kCols>>;
+    using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
+    using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
 
-//     copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
-//         <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
-//             thrust::raw_pointer_cast(d_A.data()),
-//             thrust::raw_pointer_cast(d_B.data()));
-//     cudaDeviceSynchronize();
+    dim3 dim_grid(1, 1);
+    dim3 dim_block(kThreads);
 
-//     // check correctness
-//     thrust::host_vector<Element> h_B(numel);
-//     h_B = d_B;
+    copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
+        <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
+            thrust::raw_pointer_cast(d_A.data()),
+            thrust::raw_pointer_cast(d_B.data()));
+    cudaDeviceSynchronize();
 
-//     assert_equal(
-//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
-//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())),
-//         numel);
-// }
+    // check correctness
+    thrust::host_vector<Element> h_B(numel);
+    h_B = d_B;
 
-// TEST(GlobalToSharedCopy, test_swizzled) {
-//     // In the internal implementation of the copy kernel, threads in a warp
-//     are
-//     // arranged in an 8x4 fashion. Consequently, threads in a CTA form an [8,
-//     8]
-//     // layout (derived from [1x8, 2x4]).
-//     // Given that threads in the same row access the same row in shared
-//     memory.
-//     // Each thread accesses 128 bits of data, which corresponds to 8 elements
-//     of
-//     // half-precision data. Therefore, the shared memory must have a shape
-//     that
-//     // is a multiple of [8, 64].
-//     static constexpr int kRows = 128;
-//     static constexpr int kCols = 64;
+    assert_equal(
+        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
+        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())), numel);
+}
 
-//     using WarpLayout = tl::RowMajor<1, 2>;
-//     static const int kThreads = tl::get_numel<WarpLayout> * 32;
+TEST(GlobalToSharedCopy, test_swizzled) {
+    // In the internal implementation of the copy kernel, threads in a warp are
+    // arranged in an 8x4 fashion. Consequently, threads in a CTA form an [8, 8]
+    // layout (derived from [1x8, 2x4]).
+    // Given that threads in the same row access the same row in shared memory.
+    // Each thread accesses 128 bits of data, which corresponds to 8 elements of
+    // half-precision data. Therefore, the shared memory must have a shape that
+    // is a multiple of [8, 64].
+    static constexpr int kRows = 128;
+    static constexpr int kCols = 64;
 
-//     using Element = __half;
-//     // initalize the input matrix
-//     int numel = kRows * kCols;
-//     thrust::host_vector<Element> h_A(numel);
-//     for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
+    using WarpLayout = tl::RowMajor<1, 2>;
+    static const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-//     thrust::device_vector<Element> d_B(numel);
-//     thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
-//     thrust::device_vector<Element> d_A = h_A;
+    using Element = __half;
+    // initalize the input matrix
+    int numel = kRows * kCols;
+    thrust::host_vector<Element> h_A(numel);
+    for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
 
-//     using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
-//     using SharedLayout =
-//         tl::Swizzled<tl::RowMajor<kRows, kCols>, 2, 3, 3>::Layout;
-//     using DstTile = SharedTile<Element, SharedLayout>;
-//     using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
-//     using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
+    thrust::device_vector<Element> d_B(numel);
+    thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
+    thrust::device_vector<Element> d_A = h_A;
 
-//     dim3 dim_grid(1, 1);
-//     dim3 dim_block(kThreads);
+    using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
+    using DstTile =
+        SharedTile<Element, tl::Swizzled<tl::RowMajor<kRows, kCols>, 2, 3, 3>>;
+    using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
+    using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
 
-//     copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
-//         <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
-//             thrust::raw_pointer_cast(d_A.data()),
-//             thrust::raw_pointer_cast(d_B.data()));
-//     cudaDeviceSynchronize();
+    dim3 dim_grid(1, 1);
+    dim3 dim_block(kThreads);
 
-//     // check correctness
-//     thrust::host_vector<Element> h_B(numel);
-//     h_B = d_B;
+    copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
+        <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
+            thrust::raw_pointer_cast(d_A.data()),
+            thrust::raw_pointer_cast(d_B.data()));
+    cudaDeviceSynchronize();
 
-//     assert_equal(
-//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
-//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())),
-//         numel);
-// }
+    // check correctness
+    thrust::host_vector<Element> h_B(numel);
+    h_B = d_B;
+
+    assert_equal(
+        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
+        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())), numel);
+}
 
 }  // namespace tiledcuda::testing

--- a/tests/cpp/cell/test_g2s_copy_2.cu
+++ b/tests/cpp/cell/test_g2s_copy_2.cu
@@ -29,52 +29,58 @@ __global__ void copy_g2s(const Element* src_ptr, Element* dst_ptr) {
     storer(inter, dst);
 }
 
-TEST(GlobalToSharedCopy, test_non_swizzled_layout) {
-    // In the internal implementation of the copy kernel, threads in a warp are
-    // arranged in an 8x4 fashion. Consequently, threads in a CTA form an [32,
-    // 8] layout (derived from [4x8, 2x4]).
-    // Given that threads in the same row access the same row in shared memory.
-    // Each thread accesses 128 bits of data, which corresponds to 8 elements of
-    // half-precision data. Therefore, the shared memory must have a shape that
-    // is a multiple of [32, 64].
-    static constexpr int kRows = 128;
-    static constexpr int kCols = 64;
+// TEST(GlobalToSharedCopy, test_non_swizzled_layout) {
+//     // In the internal implementation of the copy kernel, threads in a warp
+//     are
+//     // arranged in an 8x4 fashion. Consequently, threads in a CTA form an
+//     [32,
+//     // 8] layout (derived from [4x8, 2x4]).
+//     // Given that threads in the same row access the same row in shared
+//     memory.
+//     // Each thread accesses 128 bits of data, which corresponds to 8 elements
+//     of
+//     // half-precision data. Therefore, the shared memory must have a shape
+//     that
+//     // is a multiple of [32, 64].
+//     static constexpr int kRows = 128;
+//     static constexpr int kCols = 64;
 
-    using WarpLayout = tl::RowMajor<4, 2>;
-    static const int kThreads = tl::get_numel<WarpLayout> * 32;
+//     using WarpLayout = tl::RowMajor<4, 2>;
+//     static const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-    using Element = __half;
-    // initalize the input matrix
-    int numel = kRows * kCols;
-    thrust::host_vector<Element> h_A(numel);
-    for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
+//     using Element = __half;
+//     // initalize the input matrix
+//     int numel = kRows * kCols;
+//     thrust::host_vector<Element> h_A(numel);
+//     for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
 
-    thrust::device_vector<Element> d_B(numel);
-    thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
-    thrust::device_vector<Element> d_A = h_A;
+//     thrust::device_vector<Element> d_B(numel);
+//     thrust::fill(d_B.begin(), d_B.end(), static_cast<Element>(0.));
+//     thrust::device_vector<Element> d_A = h_A;
 
-    using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
-    using DstTile = SharedTile<Element, tl::RowMajor<kRows, kCols>>;
-    using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
-    using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
+//     using SrcTile = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
+//     using DstTile = SharedTile<Element, tl::RowMajor<kRows, kCols>>;
+//     using Loader = copy::GlobalToSharedLoader<DstTile, WarpLayout>;
+//     using Storer = copy::SharedToGlobalStorer<DstTile, WarpLayout>;
 
-    dim3 dim_grid(1, 1);
-    dim3 dim_block(kThreads);
+//     dim3 dim_grid(1, 1);
+//     dim3 dim_block(kThreads);
 
-    copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
-        <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
-            thrust::raw_pointer_cast(d_A.data()),
-            thrust::raw_pointer_cast(d_B.data()));
-    cudaDeviceSynchronize();
+//     copy_g2s<Element, SrcTile, DstTile, Loader, Storer>
+//         <<<dim_grid, dim_block, kRows * kCols * sizeof(Element)>>>(
+//             thrust::raw_pointer_cast(d_A.data()),
+//             thrust::raw_pointer_cast(d_B.data()));
+//     cudaDeviceSynchronize();
 
-    // check correctness
-    thrust::host_vector<Element> h_B(numel);
-    h_B = d_B;
+//     // check correctness
+//     thrust::host_vector<Element> h_B(numel);
+//     h_B = d_B;
 
-    assert_equal(
-        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
-        reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())), numel);
-}
+//     assert_equal(
+//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_A.data())),
+//         reinterpret_cast<__half*>(thrust::raw_pointer_cast(h_B.data())),
+//         numel);
+// }
 
 // TEST(GlobalToSharedCopy, test_swizzled) {
 //     // In the internal implementation of the copy kernel, threads in a warp

--- a/tests/cpp/cell/test_layout.cu
+++ b/tests/cpp/cell/test_layout.cu
@@ -40,7 +40,7 @@ TEST(TestLayout, test_swizzled_layout) {
     const int kRows = 8;
     const int kCols = 32;
     using RowMajor = tl::RowMajor<kRows, kCols>;
-    using SwizzledRowMajor = tl::Swizzled<RowMajor, 2, 3, 3>::Layout;
+    using SwizzledRowMajor = tl::Swizzled<RowMajor, 2, 3, 3>;
 
     auto layout1 = RowMajor{};
     auto layout2 = SwizzledRowMajor{};

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -5,7 +5,6 @@
 #include <glog/logging.h>
 
 namespace tiledcuda::testing {
-
 using namespace cell;
 using namespace copy;
 namespace tl = tile_layout;

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -80,12 +80,10 @@ __global__ void run_test_store(Loader& loader, Storer& storer) {
     storer(r_tile, s_tile);
     __syncthreads();
 
-#if defined(DEBUG)
     if (thread0()) {
         s_tile.dump_value();
         check_results(buf, Shared::kNumel);
     }
-#endif
 }
 }  // namespace
 
@@ -178,6 +176,7 @@ TEST(TestShared2Reg, operand_A_swizzle) {
     const int kCols = 32;
 
     using SharedLayout = tl::Swizzled<tl::RowMajor<kRows, kCols>, 2, 3, 3>;
+
     using Shared = SharedTile<Element, SharedLayout>;
     using Reg = RegTile<BaseTileRowMajor<Element>, tl::RowMajor<2, 2>>;
 

--- a/tests/cpp/cell/test_s2r_copy.cu
+++ b/tests/cpp/cell/test_s2r_copy.cu
@@ -47,6 +47,12 @@ __global__ void run_test_load(Copy& copy) {
     Reg r_tile;
 
     copy(s_tile, r_tile);
+
+#if defined(DEBUG)
+    if (thread0()) {
+        r_tile.dump_value();
+    }
+#endif
 }
 
 template <typename Shared, typename Reg, typename Loader, typename Storer>
@@ -75,14 +81,15 @@ __global__ void run_test_store(Loader& loader, Storer& storer) {
     storer(r_tile, s_tile);
     __syncthreads();
 
+#if defined(DEBUG)
     if (thread0()) {
         s_tile.dump_value();
         check_results(buf, Shared::kNumel);
     }
+#endif
 }
 }  // namespace
 
-/*
 TEST(TestShared2Reg, operand_A) {  // load mode for loading operand A in gemm
     using Element = cutlass::half_t;
 
@@ -161,7 +168,6 @@ TEST(TestReg2Shared, operand_C) {
         <<<dim_grid, dim_block, shm_size>>>(loader, storer);
     cudaDeviceSynchronize();
 }
-*/
 
 TEST(TestShared2Reg, operand_A_swizzle) {
     using Element = __half;

--- a/tests/cpp/cell/test_swizzled_layout.cu
+++ b/tests/cpp/cell/test_swizzled_layout.cu
@@ -1,0 +1,128 @@
+#include "cell/copy/mod.hpp"
+#include "cell/sync.hpp"
+#include "common/test_utils.hpp"
+#include "types/mod.hpp"
+
+#include <glog/logging.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+namespace tiledcuda::testing {
+using namespace cell;
+using namespace copy;
+namespace tl = tile_layout;
+
+namespace {
+template <typename Element>
+__device__ void init_value(Element* data, int numel) {
+    for (int i = 0; i < numel; ++i) data[i] = static_cast<Element>(i % 2048);
+}
+
+template <typename Element, typename Global, typename Shared1, typename Shared2,
+          typename Reg, typename G2S1, typename G2S2, typename S2R>
+__global__ void run_test_swizzle(const Element* data, G2S1& copy1, G2S2& copy2,
+                                 S2R& copy3) {
+    Global g_tile(data);
+
+    extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
+    auto* buf = reinterpret_cast<Element*>(buf_);
+    init_value(buf, Shared1::kNumel);
+    init_value(buf + Shared1::kNumel, Shared2::kNumel);
+
+    Shared1 s_tile(buf);
+    Shared2 s_tile_swizzled(buf + Shared1::kNumel);
+
+    copy1(g_tile, s_tile);
+    copy2(g_tile, s_tile_swizzled);
+    __copy_async();
+    __syncthreads();
+
+    Reg r_tile;
+    Reg r_tile_swizzled;
+
+    copy3(s_tile, r_tile);
+    copy3(s_tile, r_tile_swizzled);
+    __syncthreads();
+
+#if defined(DEBUG)
+    if (thread0()) {
+        printf("s_tile:\n");
+        s_tile.dump_value();
+
+        printf("\ns_tile_swizzled:\n");
+        __half* data = reinterpret_cast<__half*>(buf + Shared1::kNumel);
+        for (int i = 0; i < Shared2::kNumel; ++i) {
+            printf("%.0f, ", __half2float(data[i]));
+            if (i && i % Shared1::kCols == 0) printf("\n");
+        }
+
+        printf("\n\nr_tile:\n");
+        r_tile.dump_value();
+
+        printf("\nr_tile_swizzled:\n");
+        r_tile_swizzled.dump_value();
+    }
+#endif
+
+    for (int i = 0; i < Reg::kRows; ++i) {
+        for (int j = 0; j < Reg::kCols; ++j) {
+            auto data1 = r_tile(i, j).data();
+            auto data2 = r_tile_swizzled(i, j).data();
+
+            for (int n = 0; n < Reg::DType::kNumel; ++n) {
+                assert(data1[n] == data2[n]);
+            }
+        }
+    }
+}
+
+}  // namespace
+
+TEST(TestSwizzledLayout, test1) {
+    using Element = cutlass::half_t;
+
+    using WarpLayout = tl::RowMajor<2, 1>;
+    const int kThreads = tl::get_numel<WarpLayout> * 32;
+    static constexpr int kWarpPerRow = tl::num_rows<WarpLayout>;
+    static constexpr int kWarpPerCol = tl::num_cols<WarpLayout>;
+
+    const int kRows = 32;
+    const int kCols = 64;
+
+    const int kSc0 = kRows / kWarpPerRow / 16;
+    const int kSc1 = kCols / kWarpPerCol / 16;
+
+    // initalize the input matrix
+    int numel = kRows * kCols;
+    thrust::host_vector<Element> h_A(numel);
+    for (int i = 0; i < h_A.size(); ++i) h_A[i] = static_cast<Element>(i);
+    thrust::device_vector<Element> d_A = h_A;
+
+    using Global = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
+
+    using SharedLayout = tl::RowMajor<kRows, kCols>;
+    using SwizzledSharedLayout = tl::Swizzled<SharedLayout, 2, 3, 3>;
+
+    using Shared1 = SharedTile<Element, SharedLayout>;
+    using Shared2 = SharedTile<Element, SwizzledSharedLayout>;
+
+    using Reg = RegTile<BaseTileRowMajor<Element>, tl::RowMajor<kSc0, kSc1>>;
+
+    using G2S1 = GlobalToSharedLoader<Shared1, WarpLayout>;
+    G2S1 copy1;
+    using G2S2 = GlobalToSharedLoader<Shared2, WarpLayout>;
+    G2S2 copy2;
+    using S2R = SharedToRegLoader<Reg, WarpLayout, WarpReuse::kCont>;
+    S2R copy3;
+
+    dim3 dim_grid(1, 1, 1);
+    dim3 dim_block(kThreads, 1, 1);
+    int shm_size = (Shared1::kNumel + Shared2::kNumel) * sizeof(Element);
+
+    run_test_swizzle<Element, Global, Shared1, Shared2, Reg, G2S1, G2S2, S2R>
+        <<<dim_grid, dim_block, shm_size>>>(
+            thrust::raw_pointer_cast(d_A.data()), copy1, copy2, copy3);
+    cudaDeviceSynchronize();
+}
+
+}  // namespace tiledcuda::testing


### PR DESCRIPTION
- [x] Hide CuTe's layout inside macro kernel's implementations.
- [x] Update the gemm unittest to use the new global to shared loader and storer interfaces.
- [x] Add unittest to ensure the correctness of swizzled layout. 