### PR TITLE
fix(unittest): fix the GEMM unittest.

### DIFF
--- a/include/cell/copy/copy_atom.hpp
+++ b/include/cell/copy/copy_atom.hpp
@@ -126,6 +126,8 @@ struct GlobalToSharedBaseTileLoader {
     DEVICE void copy(const DType* src, DType* dst);
 };
 
+/// @brief  Implement loading a `16x16` BaseTile from global memory to shared
+///         memory.
 template <class Global, class Shared>
 struct GlobalToSharedBaseTileLoader<Global, Shared, tl::Layout::kRowMajor> {
     using DType = Shared::DType;
@@ -145,7 +147,7 @@ struct GlobalToSharedBaseTileLoader<Global, Shared, tl::Layout::kRowMajor> {
     using BaseShape = traits::BaseTileShape<DType>;
 
     static constexpr int kExecCount =
-        BaseShape::kCols / kNumPerAccess / kThreadsPerCol;
+        BaseShape::kCols / (kNumPerAccess * kThreadsPerCol);
 
     static_assert(
         kExecCount == 1,
@@ -225,7 +227,7 @@ struct SharedToGlobalBaseTileStorer<Shared, Global, tl::Layout::kRowMajor> {
     using BaseShape = traits::BaseTileShape<DType>;
 
     static constexpr int kExecCount =
-        BaseShape::kCols / kNumPerAccess / kThreadsPerCol;
+        BaseShape::kCols / (kNumPerAccess * kThreadsPerCol);
 
     static_assert(
         kExecCount == 1,

--- a/include/cell/copy/global_to_shared.hpp
+++ b/include/cell/copy/global_to_shared.hpp
@@ -42,19 +42,17 @@ struct GlobalToSharedLoaderImpl<Global_, Shared_, kRowExec_, kColExec_,
 
     using LoadBase =
         GlobalToSharedBaseTileLoader<Global, Shared, tl::Layout::kRowMajor>;
-
     using BaseShape = traits::BaseTileShape<DType>;
 
     static constexpr int kRowExec = kRowExec_;
     static constexpr int kColExec = kColExec_;
 
+    static constexpr int kNumPerAccess = LoadBase::kNumPerAccess;
+
     // strides to iterate over each 16x16 `BaseTile` in the shared memory
     static constexpr int kSrcRstride = BaseShape::kRows * Global::kCols;
     static constexpr int kDstRstride = BaseShape::kRows * Shared::kCols;
-
     static constexpr int kCstride = BaseShape::kCols;
-
-    static constexpr int kNumPerAccess = LoadBase::kNumPerAccess;
 
     DEVICE void operator()(const DType* src, DType* dst) {
         int lane_row = this->lane_row_id();

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -53,6 +53,7 @@ using RowMajor = MatrixLayout<kRow, kCol, kStride, 1>;
 template <const int kRow, const int kCol, const int kStride = kRow>
 using ColMajor = MatrixLayout<kRow, kCol, 1, kStride>;
 
+namespace detail {
 /// @brief Swizzled layout for 16x16 BaseTile.
 template <const int kElemBits, typename AtomLayout>
 struct SwizzledRowMajor {};
@@ -94,7 +95,6 @@ struct SwizzledRowMajor<16, AtomLayout> {
     AtomLayout layout_;
 };
 
-namespace detail {
 template <typename Shared, const bool kSwizzled, const Layout kType,
           const int kSizeOfTypeBits>
 struct SharedLayoutWrapperImpl {};

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -4,7 +4,6 @@
 #include "util/print.hpp"
 
 namespace tiledcuda::cell {
-
 namespace tl = tile_layout;
 
 template <typename Element_, typename Layout_, const bool kSwizzled_ = false>

--- a/include/util/print.hpp
+++ b/include/util/print.hpp
@@ -19,6 +19,8 @@ DEVICE void print_tile(const float* data, const Layout& layout) {
             printf("%.1f, ", data[layout(i, j)]);
         }
         printf("\n");
+
+        if (i && (i + 1) % 16 == 0) printf("\n");
     }
 }
 
@@ -32,6 +34,8 @@ DEVICE void print_tile(const cutlass::half_t* data, const Layout& layout) {
             printf("%.1f, ", __half2float(data_[layout(i, j)]));
         }
         printf("\n");
+
+        if (i && (i + 1) % 16 == 0) printf("\n");
     }
 }
 
@@ -43,6 +47,8 @@ DEVICE void print_tile(const __half* data, const Layout& layout) {
             printf("%.1f, ", __half2float(data[layout(i, j)]));
         }
         printf("\n");
+
+        if (i && (i + 1) % 16 == 0) printf("\n");
     }
 }
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -17,10 +17,7 @@ if(WITH_TESTING)
     cuda_test(${TEST_NAME} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${FILE_PATH}")
   endforeach()
 
-  # FIXME(haruhi): The global-to-shared loader has been re-implemented,
-  # necessitating further fixes to the TileIterator. Currently, the unittest
-  # cannot be compiled because TileIterator has not yet been fixed. Uncomment
-  # the unittest after resolving the issue. cuda_test(test_gemm SRCS
-  # "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
-  # "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS ${CUDA_CUBLAS_LIBRARIES})
+  cuda_test(test_gemm SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cell/test_gemm.cu"
+            "${PROJECT_SOURCE_DIR}/src/cuda_utils.cc" DEPS
+            ${CUDA_CUBLAS_LIBRARIES})
 endif()

--- a/tests/cpp/cell/test_g2s_copy_2.cu
+++ b/tests/cpp/cell/test_g2s_copy_2.cu
@@ -31,11 +31,11 @@ __global__ void copy_g2s(const Element* src_ptr, Element* dst_ptr,
     __syncthreads();
 }
 
-template <typename WarpLayout, const int kRows, const int kCols>
+template <typename Element, typename WarpLayout, const int kRows,
+          const int kCols>
 void run_test() {
     static const int kThreads = tl::get_numel<WarpLayout> * 32;
 
-    using Element = __half;
     int numel = kRows * kCols;
     thrust::host_vector<Element> h_A(numel);
     for (int i = 0; i < h_A.size(); ++i)
@@ -77,9 +77,9 @@ void run_test() {
 }  // namespace
 
 TEST(GlobalToSharedCopy, test_non_swizzled_layout) {
-    run_test<tl::RowMajor<1, 1>, 16, 16>();
-    run_test<tl::RowMajor<1, 1>, 32, 32>();
-    run_test<tl::RowMajor<2, 2>, 64, 64>();
+    run_test<__half, tl::RowMajor<1, 1>, 16, 16>();
+    run_test<__half, tl::RowMajor<1, 1>, 32, 32>();
+    run_test<__half, tl::RowMajor<2, 2>, 64, 64>();
 }
 
 }  // namespace tiledcuda::testing

--- a/tests/cpp/cell/test_layout.cu
+++ b/tests/cpp/cell/test_layout.cu
@@ -55,7 +55,7 @@ TEST(TestLayout, test_swizzled_layout) {
 
     // only siwizzle the first [16x16] half of the [kRows, kCols] matrix
     using LayoutAtom = cute::Layout<Shape<_16, _16>, Stride<Int<kCols>, _1>>;
-    using Swizzled = tl::SwizzledRowMajor<16 /*16bits*/, LayoutAtom>;
+    using Swizzled = tl::detail::SwizzledRowMajor<16 /*16bits*/, LayoutAtom>;
     Swizzled layout2;
 
     Element* ptr = thrust::raw_pointer_cast(data.data());

--- a/tests/cpp/cell/test_tile_iterator.cu
+++ b/tests/cpp/cell/test_tile_iterator.cu
@@ -4,14 +4,17 @@
 namespace tiledcuda::testing {
 
 using namespace cell;
-using namespace cute;
 namespace tl = tile_layout;
 
 namespace {
-
-template <typename Element>
-__device__ void init_value(Element* data, int numel) {
-    for (int i = 0; i < numel; ++i) data[i] = static_cast<Element>(i);
+template <typename Element, typename Layout>
+__device__ void init_value(Element* data, Layout layout) {
+    int count = 0;
+    for (int i = 0; i < Layout::kRows; ++i) {
+        for (int j = 0; j < Layout::kCols; ++j) {
+            data[layout(i, j)] = static_cast<Element>(++count);
+        }
+    }
 }
 
 template <typename Iterator>
@@ -20,7 +23,7 @@ __global__ void test_tile_iterator() {
 
     extern __shared__ __align__(sizeof(double)) unsigned char buf_[];
     auto* buf = reinterpret_cast<DType*>(buf_);
-    init_value(buf, Iterator::Tile::kNumel);
+    init_value(buf, typename Iterator::Tile::Layout{});
 
     typename Iterator::Tile s_tile(buf);
     printf("Shared tile:\n");
@@ -28,7 +31,7 @@ __global__ void test_tile_iterator() {
 
     Iterator tiles(buf);
 
-    printf("Iterate over rows.\n\n");
+    printf("\nIterate over rows.\n");
     for (int i = 0; i < Iterator::sc0; ++i) {
         printf("Iteration-[%d, _]:\n", i);
         tiles(i, _).to_tile().dump_value();
@@ -72,9 +75,10 @@ __global__ void test_tile_iterator() {
         }
     }
 }
-
 }  // namespace
 
+// FIXME(haruhi): Currently, these unit tests only output the values. Implement
+// stricter and more meaningful correctness checks.
 TEST(TestTile, test_row_major) {
     using Element = cutlass::half_t;
 
@@ -103,6 +107,28 @@ TEST(TestTile, test_col_major) {
     using Iterator = TileIterator<Tile, TileShape<2, 4>>;
 
     LOG(INFO) << std::endl << "Test Column-major" << std::endl;
+
+    int shm_size = Tile::kNumel * sizeof(Element);
+    // DONOT change this launch config. The unittest is implemented for a
+    // single thread.
+    test_tile_iterator<Iterator><<<1, 1, shm_size>>>();
+    cudaDeviceSynchronize();
+}
+
+TEST(TestTile, test_swizzled_row_major) {
+    using Element = float;
+
+    const int rows = 16;
+    const int cols = 16;
+
+    const int chunked_row = 16;
+    const int chunked_col = 16;
+
+    using Layout = tl::RowMajor<rows, cols>;
+    using Tile = SharedTile<Element, Layout, true>;
+    using Iterator = TileIterator<Tile, TileShape<chunked_row, chunked_col>>;
+
+    LOG(INFO) << std::endl << "Test Row-major" << std::endl;
 
     int shm_size = Tile::kNumel * sizeof(Element);
     // DONOT change this launch config. The unittest is implemented for a


### PR DESCRIPTION
The GEMM unit test in the master branch fails to compile after we refactored the global-to-shared loader/store to use a 16x16 BaseTile, making it be able to be compatible with shared memory swizzling.

The current implementation does not support storing floating-point numbers from shared to global memory.

To fix this, this PR modify the GEMM unit test to store GEMM's output directly from the register to global memory.