### PR TITLE
fix(cell): Reduce bank conflicts when accessing shared memory tiles with float data type

### DIFF
--- a/include/cell/copy/copy_atom.hpp
+++ b/include/cell/copy/copy_atom.hpp
@@ -60,7 +60,7 @@ struct LoadMatBase {
     }
 };
 
-template <typename Shared, const tl::Layout kType, const size_t kBitPerAccess>
+template <typename Shared, const tl::Layout kType, const size_t kElemBits>
 struct BaseTileStorer;
 
 /// TODO(haruhi): try to reduece reusable codes.
@@ -148,8 +148,6 @@ struct BaseTileStorer<Shared, tl::Layout::kRowMajor, 32> {
     }
 
   private:
-    using BaseTileSharedLayout = tl::SharedLayoutWrapper<Shared>::Layout;
-
     // the thread layout for wmma's output tile.
     using ThreadLayout = tile_layout::RowMajor<8, 4>;
     static constexpr int kWarpSize = 32;
@@ -172,7 +170,7 @@ struct BaseTileStorer<Shared, tl::Layout::kRowMajor, 32> {
         return (threadIdx.x % kWarpSize) % tl::num_cols<ThreadLayout>;
     }
 
-    BaseTileSharedLayout in_tile_;
+    typename tl::SharedLayoutWrapper<Shared>::Layout in_tile_;
 };
 
 /// TODO(haruhi): try to reduece reusable codes.
@@ -204,8 +202,6 @@ struct BaseTileStorer<Shared, tl::Layout::kColMajor, 16> {
     }
 
   private:
-    using BaseTileSharedLayout = tl::SharedLayoutWrapper<Shared>::Layout;
-
     // the thread layout for wmma's output tile.
     using ThreadLayout = tile_layout::ColMajor<4, 8>;
 
@@ -229,7 +225,7 @@ struct BaseTileStorer<Shared, tl::Layout::kColMajor, 16> {
         return (threadIdx.x % kWarpSize) / tl::num_rows<ThreadLayout>;
     }
 
-    BaseTileSharedLayout in_tile_;
+    typename tl::SharedLayoutWrapper<Shared>::Layout in_tile_;
 };
 
 /// TODO(haruhi): try to reduece reusable codes.
@@ -261,8 +257,6 @@ struct BaseTileStorer<Shared, tl::Layout::kColMajor, 32> {
     }
 
   private:
-    using BaseTileSharedLayout = tl::SharedLayoutWrapper<Shared>::Layout;
-
     // the thread layout for wmma's output tile.
     using ThreadLayout = tile_layout::ColMajor<4, 8>;
     static constexpr int kWarpSize = 32;
@@ -285,15 +279,11 @@ struct BaseTileStorer<Shared, tl::Layout::kColMajor, 32> {
         return (threadIdx.x % kWarpSize) / tl::num_rows<ThreadLayout>;
     }
 
-    BaseTileSharedLayout in_tile_;
+    typename tl::SharedLayoutWrapper<Shared>::Layout in_tile_;
 };
 
 template <class Global, class Shared, const tl::Layout kType>
-struct GlobalToSharedBaseTileLoader {
-    using DType = Shared::DType;
-
-    DEVICE void copy(const DType* src, DType* dst);
-};
+struct GlobalToSharedBaseTileLoader;
 
 /// @brief  Implement loading a `16x16` BaseTile from global memory to shared
 ///         memory.

--- a/include/cell/copy/shared_to_register.hpp
+++ b/include/cell/copy/shared_to_register.hpp
@@ -15,12 +15,7 @@ namespace detail {
 
 template <typename Shared, typename Reg_, const int kRowExec,
           const int kColExec, const tl::Layout kType, CopyInst kCopyInst>
-struct SharedToRegLoaderImpl {
-    using DType = typename Shared::DType;
-    using Reg = Reg_;
-
-    DEVICE void operator()(const DType* src, Reg& dst);
-};
+struct SharedToRegLoaderImpl;
 
 /// @brief partial specialization for row-major shared memory tile.
 template <typename Shared, typename Reg_, const int kRowExec_,
@@ -123,12 +118,7 @@ struct SharedToRegLoaderImpl<Shared, Reg_, kRowExec_, kColExec_,
 
 template <typename Shared, typename Reg_, const int kRowExec_,
           const int kColExec_, const tl::Layout kType>
-struct RegToSharedStorerImpl {
-    using DType = typename Shared::DType;
-    using Reg = Reg_;
-
-    DEVICE void operator()(const Reg& src, DType* dst);
-};
+struct RegToSharedStorerImpl;
 
 template <typename Shared, typename Reg_, const int kRowExec_,
           const int kColExec_>
@@ -158,9 +148,9 @@ struct RegToSharedStorerImpl<Shared, Reg_, kRowExec_, kColExec_,
         tl::MatrixLayout<kRowExec, kColExec,
                          BaseShape::kRows * Shared::kRowStride,
                          BaseShape::kCols>;
-    using Storer = BaseTileStorer<Shared, Shared::kType, sizeof(DType) * 8>;
-
     BaseTilesLayout base_tiles_;
+
+    using Storer = BaseTileStorer<Shared, Shared::kType, sizeof(DType) * 8>;
     Storer storer_;
 };
 
@@ -191,10 +181,9 @@ struct RegToSharedStorerImpl<Shared, Reg_, kRowExec_, kColExec_,
     using BaseTilesLayout =
         tl::MatrixLayout<kRowExec, kColExec, BaseShape::kRows,
                          BaseShape::kCols * Shared::kColStride>;
+    BaseTilesLayout base_tiles_;
 
     using Storer = BaseTileStorer<Shared, Shared::kType, sizeof(DType) * 8>;
-
-    BaseTilesLayout base_tiles_;
     Storer storer_;
 };
 }  // namespace  detail

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -190,11 +190,20 @@ struct SwizzledColMajor<32, AtomLayout> {
 
 template <typename Shared, const bool kSwizzled, const Layout kType,
           const int kSizeOfTypeBits>
-struct SharedLayoutWrapperImpl {};
+struct SharedLayoutWrapperImpl;
 
 /// @brief Shared memory layout for non-swizzled layout with 16-bit data type.
 template <typename Shared, const Layout kType>
 struct SharedLayoutWrapperImpl<Shared, false, kType, 16> {
+    using BaseShape = traits::BaseTileShape<typename Shared::DType>;
+    using Layout =
+        cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
+                     Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
+};
+
+/// @brief Shared memory layout for non-swizzled layout with 32-bit data type.
+template <typename Shared, const Layout kType>
+struct SharedLayoutWrapperImpl<Shared, false, kType, 32> {
     using BaseShape = traits::BaseTileShape<typename Shared::DType>;
     using Layout =
         cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
@@ -211,6 +220,17 @@ struct SharedLayoutWrapperImpl<Shared, true, Layout::kRowMajor, 16> {
                      Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
 
     using Layout = SwizzledRowMajor<16, LayoutAtom>;
+};
+
+/// @brief Shared memory layout for swizzled layout with 32-bit data type.
+template <typename Shared>
+struct SharedLayoutWrapperImpl<Shared, true, Layout::kRowMajor, 32> {
+    using BaseShape = traits::BaseTileShape<typename Shared::DType>;
+    using LayoutAtom =
+        cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
+                     Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
+
+    using Layout = SwizzledRowMajor<32, LayoutAtom>;
 };
 
 /// @brief Shared memory layout for swizzled col-major layout with 16-bit data
@@ -235,26 +255,6 @@ struct SharedLayoutWrapperImpl<Shared, true, Layout::kColMajor, 32> {
                      Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
 
     using Layout = SwizzledColMajor<32, LayoutAtom>;
-};
-
-/// @brief Shared memory layout for non-swizzled layout with 32-bit data type.
-template <typename Shared, const Layout kType>
-struct SharedLayoutWrapperImpl<Shared, false, kType, 32> {
-    using BaseShape = traits::BaseTileShape<typename Shared::DType>;
-    using Layout =
-        cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
-                     Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
-};
-
-/// @brief Shared memory layout for swizzled layout with 32-bit data type.
-template <typename Shared>
-struct SharedLayoutWrapperImpl<Shared, true, Layout::kRowMajor, 32> {
-    using BaseShape = traits::BaseTileShape<typename Shared::DType>;
-    using LayoutAtom =
-        cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
-                     Stride<Int<Shared::kRowStride>, Int<Shared::kColStride>>>;
-
-    using Layout = SwizzledRowMajor<32, LayoutAtom>;
 };
 }  // namespace detail
 

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -99,20 +99,16 @@ struct SwizzledRowMajor<32, AtomLayout> {
     using BaseShape = traits::BaseTileShape<float>;
 
     static constexpr int kB = 2;
-    static constexpr int kM = 3;
+    static constexpr int kM = 2;
     static constexpr int kS = 3;
 
-    static_assert(
-        BaseShape::kNumel == ((1 << kB) * (1 << kM) * (1 << kS)),
-        "Swizzling is performed based on the BaseTile, and the number of "
-        "elements in a BaseTile should be equal to 2^B x 2^S x 2^M.");
-
-    using BaseTileLayout =
+    using SwizzledAtom =
+        decltype(composition(cute::Swizzle<kB, kM, kS>{},
+                             cute::Layout<Shape<_16, _8>, Stride<_8, _1>>{}));
+    using SwizzledBaseTile = decltype(tile_to_shape(
+        SwizzledAtom{},
         cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
-                     Stride<Int<BaseShape::kCols>, _1>>;
-
-    using SwizzledBaseTile =
-        decltype(composition(cute::Swizzle<kB, kM, kS>{}, BaseTileLayout{}));
+                     Stride<Int<BaseShape::kCols>, _1>>{}));
 
     DEVICE SwizzledRowMajor()
         : swizzled_(SwizzledBaseTile{}), layout_(AtomLayout{}){};
@@ -123,7 +119,6 @@ struct SwizzledRowMajor<32, AtomLayout> {
     }
 
   private:
-    BaseTileLayout base_tile_layout_;
     SwizzledBaseTile swizzled_;
     AtomLayout layout_;
 };
@@ -168,16 +163,15 @@ struct SwizzledColMajor<32, AtomLayout> {
     using BaseShape = traits::BaseTileShape<__half>;
 
     static constexpr int kB = 2;
-    static constexpr int kM = 3;
+    static constexpr int kM = 2;
     static constexpr int kS = 3;
 
-    static_assert(
-        BaseShape::kNumel == ((1 << kB) * (1 << kM) * (1 << kS)),
-        "Swizzling is performed based on the BaseTile, and the number of "
-        "elements in a BaseTile should be equal to 2^B x 2^S x 2^M.");
+    using SwizzledAtom =
+        decltype(composition(cute::Swizzle<kB, kM, kS>{},
+                             cute::Layout<Shape<_16, _8>, Stride<_1, _16>>{}));
 
-    using SwizzledBaseTile = decltype(composition(
-        cute::Swizzle<kB, kM, kS>{},
+    using SwizzledBaseTile = decltype(tile_to_shape(
+        SwizzledAtom{},
         cute::Layout<Shape<Int<BaseShape::kRows>, Int<BaseShape::kCols>>,
                      Stride<_1, Int<BaseShape::kRows>>>{}));
 

--- a/tests/cpp/cell/test_swizzled_copy.cu
+++ b/tests/cpp/cell/test_swizzled_copy.cu
@@ -404,7 +404,6 @@ void test_col_major_store() {
     assert_equal(thrust::raw_pointer_cast(h_src.data()),
                  thrust::raw_pointer_cast(h_dst.data()), numel, 1e-4);
 };
-
 }  // namespace
 
 TEST(TestSwizzledLayout, test_load_row_major) {
@@ -452,7 +451,15 @@ TEST(TestNonSwizzledStore, test_row_major) {
 
 TEST(TestSwizzledStored, test_row_major) {
     static constexpr int kSwizzled = true;
+    // bank conflict free
     test_row_major_store<float, tl::RowMajor<1, 1>, 16, 16, kSwizzled>();
+    // bank conflict free
+    test_row_major_store<float, tl::RowMajor<1, 1>, 16, 48, kSwizzled>();
+
+    // FIXME(haruhi): below cases has bank conflicts
+    // FIXME(haruhi): a single BaseTile read/access shared memory has 8 bank
+    // conflicts, this tese case has 32 bank conflicts in total
+    test_row_major_store<float, tl::RowMajor<1, 1>, 16, 32, kSwizzled>();
     test_row_major_store<float, tl::RowMajor<2, 1>, 64, 32, kSwizzled>();
     test_row_major_store<float, tl::RowMajor<1, 2>, 128, 64, kSwizzled>();
     test_row_major_store<float, tl::RowMajor<2, 2>, 64, 64, kSwizzled>();

--- a/tests/cpp/cell/test_swizzled_copy.cu
+++ b/tests/cpp/cell/test_swizzled_copy.cu
@@ -455,13 +455,20 @@ TEST(TestSwizzledStored, test_row_major) {
     test_row_major_store<float, tl::RowMajor<1, 1>, 16, 16, kSwizzled>();
     // bank conflict free
     test_row_major_store<float, tl::RowMajor<1, 1>, 16, 48, kSwizzled>();
+    // bank conflict free
+    test_row_major_store<float, tl::RowMajor<2, 1>, 32, 48, kSwizzled>();
 
-    // FIXME(haruhi): below cases has bank conflicts
-    // FIXME(haruhi): a single BaseTile read/access shared memory has 8 bank
-    // conflicts, this tese case has 32 bank conflicts in total
+    // FIXME(haruhi): below test cases have bank conflicts. In the current
+    // implementation, a single `BaseTile` store/load shared memory will cause 8
+    // bank conflicts.
+
+    // This test case has 32 bank conflicts in total
     test_row_major_store<float, tl::RowMajor<1, 1>, 16, 32, kSwizzled>();
+    // This test case has 128 bank conflicts in total
     test_row_major_store<float, tl::RowMajor<2, 1>, 64, 32, kSwizzled>();
+    // This test case has 512 bank conflicts in total
     test_row_major_store<float, tl::RowMajor<1, 2>, 128, 64, kSwizzled>();
+    // This test case has 256 bank conflicts in total
     test_row_major_store<float, tl::RowMajor<2, 2>, 64, 64, kSwizzled>();
 }
 


### PR DESCRIPTION
1. This pull request reduces bank conflicts for register-to-shared and shared-to-global storer. In the current implementation, **storing a single `BaseTile` in shared memory causes 8 bank conflicts**.
2. A thorough fix to make the storing process free of bank conflicts requires **more careful consideration**. I hope to merge this fix and benchmark the end-to-end performance for GEMM.
3. The loaders are bank-conflict free.

The data distribution for a single `BaseTile` according to the swizzle function used in this fix is as follows:

![data_distribution](https://github.com/user-attachments/assets/eff2840f-5ff6-4d71-b2e0-c7b735866398)